### PR TITLE
Clean up imports to follow google python style guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ This package provides an implementation of the [Service to Service Authenticatio
 ### To create a JWT for authentication
 
 ```python
-    from atlassian_jwt_auth.signer import create_signer
+    import atlassian_jwt_auth
 
 
-    signer = create_signer('issuer', 'issuer/key', private_key_pem)
+    signer = atlassian_jwt_auth.create_signer('issuer', 'issuer/key', private_key_pem)
     a_jwt = signer.generate_jwt('audience')
 ```
 
@@ -21,22 +21,20 @@ This package provides an implementation of the [Service to Service Authenticatio
 Each time you call `generate_jwt` this will find the latest active key file (ends with `.pem`) and use it to generate your JWT.
 
 ```python
-    from atlassian_jwt_auth.signer import create_signer_from_private_key_repository
+    import atlassian_jwt_auth
 
 
-    signer = create_signer_from_private_key_repository('issuer', '/opt/jwtprivatekeys')
+    signer = atlassian_jwt_auth.create_signer_from_file_private_key_repository('issuer', '/opt/jwtprivatekeys')
     a_jwt = signer.generate_jwt('audience')
 ```
 
 
 ### To verify a JWT
 ```python
-    from atlassian_jwt_auth.key import HTTPSPublicKeyRetriever
-    from atlassian_jwt_auth.verifier import JWTAuthVerifier
+    import atlassian_jwt_auth
 
-
-    public_key_retriever = HTTPSPublicKeyRetriever('https://example.com')
-    verifier = JWTAuthVerifier(public_key_retriever)
+    public_key_retriever = atlassian_jwt_auth.HTTPSPublicKeyRetriever('https://example.com')
+    verifier = atlassian_jwt_auth.JWTAuthVerifier(public_key_retriever)
     verified_claims = verifier.verify_jwt(a_jwt, 'audience')
 ```
 

--- a/atlassian_jwt_auth/__init__.py
+++ b/atlassian_jwt_auth/__init__.py
@@ -1,16 +1,15 @@
-__version__ = '1.0.6'
+from atlassian_jwt_auth.algorithms import get_permitted_algorithm_names
 
+from atlassian_jwt_auth.signer import (
+    create_signer,
+    create_signer_from_file_private_key_repository,
+)
 
-def get_permitted_algorithm_names():
-    """ returns permitted algorithm names. """
-    return [
-        'RS256',
-        'RS384',
-        'RS512',
-        'ES256',
-        'ES384',
-        'ES512',
-        'PS256',
-        'PS384',
-        'PS512'
-    ]
+from atlassian_jwt_auth.key import (
+    KeyIdentifier,
+    HTTPSPublicKeyRetriever,
+)
+
+from atlassian_jwt_auth.verifier import (
+    JWTAuthVerifier,
+)

--- a/atlassian_jwt_auth/algorithms.py
+++ b/atlassian_jwt_auth/algorithms.py
@@ -1,0 +1,13 @@
+def get_permitted_algorithm_names():
+    """ returns permitted algorithm names. """
+    return [
+        'RS256',
+        'RS384',
+        'RS512',
+        'ES256',
+        'ES384',
+        'ES512',
+        'PS256',
+        'PS384',
+        'PS512'
+    ]

--- a/atlassian_jwt_auth/key.py
+++ b/atlassian_jwt_auth/key.py
@@ -1,7 +1,7 @@
 import os
 import re
 
-from cachecontrol import CacheControlAdapter
+import cachecontrol
 import jwt
 import requests
 
@@ -60,7 +60,7 @@ class HTTPSPublicKeyRetriever(object):
         if self._session is not None:
             return self._session
         session = requests.Session()
-        session.mount('https://', CacheControlAdapter())
+        session.mount('https://', cachecontrol.CacheControlAdapter())
         self._session = session
         return self._session
 

--- a/atlassian_jwt_auth/signer.py
+++ b/atlassian_jwt_auth/signer.py
@@ -1,13 +1,10 @@
 import datetime
-from random import SystemRandom
+import random
 
 import jwt
 
-from . import get_permitted_algorithm_names
-from .key import (
-    StaticPrivateKeyRetriever,
-    FilePrivateKeyRetriever
-)
+from atlassian_jwt_auth import algorithms
+from atlassian_jwt_auth import key
 
 
 class JWTAuthSigner(object):
@@ -18,7 +15,8 @@ class JWTAuthSigner(object):
         self.lifetime = kwargs.get('lifetime', datetime.timedelta(hours=1))
         self.algorithm = kwargs.get('algorithm', 'RS256')
 
-        if self.algorithm not in set(get_permitted_algorithm_names()):
+        if self.algorithm not in set(
+                algorithms.get_permitted_algorithm_names()):
             raise ValueError("Algorithm, '%s', is not permitted." %
                              self.algorithm)
         if self.lifetime > datetime.timedelta(hours=1):
@@ -34,7 +32,7 @@ class JWTAuthSigner(object):
             'iat': now,
             'aud': audience,
             'jti': '%s:%s' % (
-                now.strftime('%s'), SystemRandom().getrandbits(32)),
+                now.strftime('%s'), random.SystemRandom().getrandbits(32)),
             'nbf': now,
             'sub': self.issuer,
         }
@@ -54,7 +52,7 @@ class JWTAuthSigner(object):
 
 
 def create_signer(issuer, key_identifier, private_key_pem, **kwargs):
-    private_key_retriever = StaticPrivateKeyRetriever(
+    private_key_retriever = key.StaticPrivateKeyRetriever(
         key_identifier, private_key_pem)
     signer = JWTAuthSigner(issuer, private_key_retriever, **kwargs)
     return signer
@@ -62,7 +60,7 @@ def create_signer(issuer, key_identifier, private_key_pem, **kwargs):
 
 def create_signer_from_file_private_key_repository(
         issuer, private_key_repository, **kwargs):
-    private_key_retriever = FilePrivateKeyRetriever(
+    private_key_retriever = key.FilePrivateKeyRetriever(
         issuer, private_key_repository)
     signer = JWTAuthSigner(issuer, private_key_retriever, **kwargs)
     return signer

--- a/atlassian_jwt_auth/tests/test_key.py
+++ b/atlassian_jwt_auth/tests/test_key.py
@@ -1,6 +1,6 @@
 import unittest
 
-from ..key import KeyIdentifier
+import atlassian_jwt_auth
 
 
 class TestKeyModule(unittest.TestCase):
@@ -15,10 +15,10 @@ class TestKeyModule(unittest.TestCase):
                 ]
         for key in keys:
             with self.assertRaises(ValueError):
-                KeyIdentifier(identifier=key)
+                atlassian_jwt_auth.KeyIdentifier(identifier=key)
 
     def test_key_identifier_with_valid_keys(self):
         """ test that valid keys work as expected. """
         for key in ['oa.oo/a', 'oo.sasdf.asdf/yes', 'oo/o']:
-            key_id = KeyIdentifier(identifier=key)
+            key_id = atlassian_jwt_auth.KeyIdentifier(identifier=key)
             self.assertEqual(key_id.key_id, key)

--- a/atlassian_jwt_auth/tests/test_signer.py
+++ b/atlassian_jwt_auth/tests/test_signer.py
@@ -3,12 +3,8 @@ import unittest
 
 import mock
 
-from ..signer import create_signer
-from .utils import (
-    get_example_jwt_auth_signer,
-    RS256KeyTestMixin,
-    ES256KeyTestMixin,
-)
+import atlassian_jwt_auth
+from atlassian_jwt_auth.tests import utils
 
 
 class BaseJWTAuthSignerTest(object):
@@ -24,7 +20,7 @@ class BaseJWTAuthSignerTest(object):
         expected_audience = 'example_aud'
         expected_iss = 'eg'
         expected_key_id = 'eg/ex'
-        jwt_auth_signer = create_signer(
+        jwt_auth_signer = atlassian_jwt_auth.create_signer(
             expected_iss,
             expected_key_id,
             self._private_key_pem)
@@ -46,7 +42,7 @@ class BaseJWTAuthSignerTest(object):
         """ tests that the jti of a claim changes. """
         expected_now = datetime.datetime(year=2001, day=1, month=1)
         aud = 'aud'
-        jwt_auth_signer = get_example_jwt_auth_signer(
+        jwt_auth_signer = utils.get_example_jwt_auth_signer(
             algorithm=self.algorithm, private_key_pem=self._private_key_pem)
         jwt_auth_signer._now = lambda: expected_now
         first = jwt_auth_signer._generate_claims(aud)['jti']
@@ -62,7 +58,7 @@ class BaseJWTAuthSignerTest(object):
         expected_claims = {'eg': 'ex'}
         expected_key_id = 'key_id'
         expected_issuer = 'a_issuer'
-        jwt_auth_signer = create_signer(
+        jwt_auth_signer = atlassian_jwt_auth.create_signer(
             expected_issuer,
             expected_key_id,
             private_key_pem=self._private_key_pem,
@@ -79,13 +75,13 @@ class BaseJWTAuthSignerTest(object):
 
 class JWTAuthSignerRS256Test(
         BaseJWTAuthSignerTest,
-        RS256KeyTestMixin,
+        utils.RS256KeyTestMixin,
         unittest.TestCase):
     pass
 
 
 class JWTAuthSignerES256Test(
         BaseJWTAuthSignerTest,
-        ES256KeyTestMixin,
+        utils.ES256KeyTestMixin,
         unittest.TestCase):
     pass

--- a/atlassian_jwt_auth/tests/test_verifier.py
+++ b/atlassian_jwt_auth/tests/test_verifier.py
@@ -3,13 +3,8 @@ import unittest
 
 import mock
 
-from ..signer import create_signer
-from ..verifier import JWTAuthVerifier
-from .utils import (
-    get_public_key_pem_for_private_key_pem,
-    RS256KeyTestMixin,
-    ES256KeyTestMixin,
-)
+import atlassian_jwt_auth
+from atlassian_jwt_auth.tests import utils
 
 
 class BaseJWTAuthVerifierTest(object):
@@ -18,12 +13,12 @@ class BaseJWTAuthVerifierTest(object):
 
     def setUp(self):
         self._private_key_pem = self.get_new_private_key_in_pem_format()
-        self._public_key_pem = get_public_key_pem_for_private_key_pem(
+        self._public_key_pem = utils.get_public_key_pem_for_private_key_pem(
             self._private_key_pem)
         self._example_aud = 'aud_x'
         self._example_issuer = 'egissuer'
         self._example_key_id = '%s/a' % self._example_issuer
-        self._jwt_auth_signer = create_signer(
+        self._jwt_auth_signer = atlassian_jwt_auth.create_signer(
             self._example_issuer,
             self._example_key_id,
             self._private_key_pem.decode(),
@@ -37,7 +32,7 @@ class BaseJWTAuthVerifierTest(object):
 
     def _setup_jwt_auth_verifier(self, pub_key_pem):
         m_public_key_ret = self._setup_mock_public_key_retriever(pub_key_pem)
-        return JWTAuthVerifier(m_public_key_ret)
+        return atlassian_jwt_auth.JWTAuthVerifier(m_public_key_ret)
 
     def test_verify_jwt_with_valid_jwt(self):
         """ test that verify_jwt verifies a valid jwt. """
@@ -54,7 +49,7 @@ class BaseJWTAuthVerifierTest(object):
             not start with the claimed issuer.
         """
         verifier = self._setup_jwt_auth_verifier(self._public_key_pem)
-        signer = create_signer(
+        signer = atlassian_jwt_auth.create_signer(
             'issuer', 'issuerx', self._private_key_pem.decode(),
             algorithm=self.algorithm,
         )
@@ -109,13 +104,13 @@ class BaseJWTAuthVerifierTest(object):
 
 class JWTAuthVerifierRS256Test(
         BaseJWTAuthVerifierTest,
-        RS256KeyTestMixin,
+        utils.RS256KeyTestMixin,
         unittest.TestCase):
     pass
 
 
 class JWTAuthVerifierES256Test(
         BaseJWTAuthVerifierTest,
-        ES256KeyTestMixin,
+        utils.ES256KeyTestMixin,
         unittest.TestCase):
     pass

--- a/atlassian_jwt_auth/tests/utils.py
+++ b/atlassian_jwt_auth/tests/utils.py
@@ -3,7 +3,7 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives import serialization
 
-from ..signer import create_signer
+import atlassian_jwt_auth
 
 
 def get_new_rsa_private_key_in_pem_format():
@@ -37,7 +37,8 @@ def get_example_jwt_auth_signer(**kwargs):
     key = kwargs.get(
         'private_key_pem', get_new_rsa_private_key_in_pem_format())
     algorithm = kwargs.get('algorithm', 'RS256')
-    return create_signer(issuer, key_id, key, algorithm=algorithm)
+    return atlassian_jwt_auth.create_signer(
+        issuer, key_id, key, algorithm=algorithm)
 
 
 class BaseJWTAlgorithmTestMixin(object):

--- a/atlassian_jwt_auth/verifier.py
+++ b/atlassian_jwt_auth/verifier.py
@@ -1,7 +1,7 @@
 import jwt
 
-from . import get_permitted_algorithm_names
-from .key import _get_key_id_from_jwt_header
+from atlassian_jwt_auth import algorithms
+from atlassian_jwt_auth import key
 
 
 class JWTAuthVerifier(object):
@@ -10,7 +10,7 @@ class JWTAuthVerifier(object):
 
     def __init__(self, public_key_retriever, **kwargs):
         self.public_key_retriever = public_key_retriever
-        self.algorithms = get_permitted_algorithm_names()
+        self.algorithms = algorithms.get_permitted_algorithm_names()
         self._seen_jti = set()
 
     def verify_jwt(self, a_jwt, audience, **requests_kwargs):
@@ -18,7 +18,7 @@ class JWTAuthVerifier(object):
             is successful.
         """
         options = {'verify_signature': True}
-        key_identifier = _get_key_id_from_jwt_header(a_jwt)
+        key_identifier = key._get_key_id_from_jwt_header(a_jwt)
         public_key = self.public_key_retriever.retrieve(
             key_identifier, **requests_kwargs)
         claims = jwt.decode(


### PR DESCRIPTION
- Remove relative imports
- Only import modules, not classes or functions
- Expose public classes through factory functions in __init__.py