### PR TITLE
Fix an issue where Flask config values were not referenced properly

### DIFF
--- a/atlassian_jwt_auth/contrib/flask_app/decorators.py
+++ b/atlassian_jwt_auth/contrib/flask_app/decorators.py
@@ -42,9 +42,9 @@ def requires_asap(f):
 
 
 def _get_verifier():
-    """Returns a verifier based on config.asap['PUBLICKEY_REPOSITORY']"""
+    """Returns a verifier based on config['ASAP_PUBLICKEY_REPOSITORY']"""
     return atlassian_jwt_auth.JWTAuthVerifier(
         atlassian_jwt_auth.HTTPSPublicKeyRetriever(
-            current_app.config.asap['PUBLICKEY_REPOSITORY']
+            current_app.config['ASAP_PUBLICKEY_REPOSITORY']
         )
     )

--- a/atlassian_jwt_auth/contrib/flask_app/utils.py
+++ b/atlassian_jwt_auth/contrib/flask_app/utils.py
@@ -6,11 +6,11 @@ def parse_jwt(verifier, encoded_jwt):
     """Decode an encoded JWT using stored config."""
     claims = verifier.verify_jwt(
         encoded_jwt,
-        current_app.config.asap['VALID_AUDIENCE'],
+        current_app.config['ASAP_VALID_AUDIENCE'],
         leeway=60
     )
 
-    valid_issuers = current_app.config.asap.get('VALID_ISSUERS')
+    valid_issuers = current_app.config.get('ASAP_VALID_ISSUERS')
     if valid_issuers and claims.get('iss') not in valid_issuers:
         raise InvalidIssuerError
 

--- a/atlassian_jwt_auth/contrib/tests/test_flask.py
+++ b/atlassian_jwt_auth/contrib/tests/test_flask.py
@@ -11,10 +11,10 @@ from atlassian_jwt_auth.contrib.tests.utils import static_verifier
 
 def get_app():
     app = Flask(__name__)
-    app.config.asap = {
-        'VALID_AUDIENCE': 'server-app',
-        'VALID_ISSUERS': ['client-app']
-    }
+    app.config.update({
+        'ASAP_VALID_AUDIENCE': 'server-app',
+        'ASAP_VALID_ISSUERS': ('client-app',)
+    })
 
     @app.route("/")
     @requires_asap


### PR DESCRIPTION
So... it looks like Flask configuration values are usually referenced as `app.config['MY_VAL']` instead of `app.config.my_val`. I based my initial version of the Flask stuff on faulty assumptions based on a bad example.

This PR fixes that by referencing the values properly.