### PR TITLE
Add better settings for test

### DIFF
--- a/atlassian_jwt_auth/contrib/flask_app/decorators.py
+++ b/atlassian_jwt_auth/contrib/flask_app/decorators.py
@@ -46,9 +46,7 @@ def _get_verifier():
     retriever_cls = current_app.config.get(
         'ASAP_KEY_RETRIEVER_CLASS', atlassian_jwt_auth.HTTPSPublicKeyRetriever
     )
-
     retriever = retriever_cls(
         base_url=current_app.config.get('ASAP_PUBLICKEY_REPOSITORY')
     )
-
     return atlassian_jwt_auth.JWTAuthVerifier(retriever)

--- a/atlassian_jwt_auth/contrib/flask_app/decorators.py
+++ b/atlassian_jwt_auth/contrib/flask_app/decorators.py
@@ -48,7 +48,7 @@ def _get_verifier():
     )
 
     retriever = retriever_cls(
-        base_url=current_app.config['ASAP_PUBLICKEY_REPOSITORY']
+        base_url=current_app.config.get('ASAP_PUBLICKEY_REPOSITORY')
     )
 
     return atlassian_jwt_auth.JWTAuthVerifier(retriever)

--- a/atlassian_jwt_auth/contrib/flask_app/decorators.py
+++ b/atlassian_jwt_auth/contrib/flask_app/decorators.py
@@ -42,9 +42,13 @@ def requires_asap(f):
 
 
 def _get_verifier():
-    """Returns a verifier based on config['ASAP_PUBLICKEY_REPOSITORY']"""
-    return atlassian_jwt_auth.JWTAuthVerifier(
-        atlassian_jwt_auth.HTTPSPublicKeyRetriever(
-            current_app.config['ASAP_PUBLICKEY_REPOSITORY']
-        )
+    """Returns a verifier for ASAP JWT tokens basd on application settings"""
+    retriever_cls = current_app.config.get(
+        'ASAP_KEY_RETRIEVER_CLASS', atlassian_jwt_auth.HTTPSPublicKeyRetriever
     )
+
+    retriever = retriever_cls(
+        base_url=current_app.config['ASAP_PUBLICKEY_REPOSITORY']
+    )
+
+    return atlassian_jwt_auth.JWTAuthVerifier(retriever)

--- a/atlassian_jwt_auth/contrib/tests/utils.py
+++ b/atlassian_jwt_auth/contrib/tests/utils.py
@@ -1,20 +1,21 @@
 import atlassian_jwt_auth
 
 
-class StaticPublicKeyRetriever(object):
-    """ Retrieves a key from a static list of public keys
-    (for use in tests only) """
-    def __init__(self, key_dict):
-        self.keys = key_dict or {}
+def get_static_retriever_class(keys):
 
-    def add_key(self, key_id, value):
-        self.keys[key_id] = value
+    class StaticPublicKeyRetriever(object):
+        """ Retrieves a key from a static list of public keys
+        (for use in tests only) """
+        def __init__(self, *args, **kwargs):
+            self.keys = keys
 
-    def retrieve(self, key_identifier, **requests_kwargs):
-        return self.keys[key_identifier.key_id]
+        def retrieve(self, key_identifier, **requests_kwargs):
+            return self.keys[key_identifier.key_id]
+
+    return StaticPublicKeyRetriever
 
 
 def static_verifier(keys):
     return atlassian_jwt_auth.JWTAuthVerifier(
-        StaticPublicKeyRetriever(keys)
+        get_static_retriever_class(keys)()
     )

--- a/atlassian_jwt_auth/key.py
+++ b/atlassian_jwt_auth/key.py
@@ -59,7 +59,7 @@ class HTTPSPublicKeyRetriever(object):
     """
 
     def __init__(self, base_url):
-        if not base_url.startswith('https://'):
+        if base_url is None or not base_url.startswith('https://'):
             raise ValueError('The base url must start with https://')
         if not base_url.endswith('/'):
             base_url += '/'


### PR DESCRIPTION
This PR makes testing with Flask MUCH easier by adding an optional ASAP_KEY_RETRIEVER_CLASS setting to specify a class that can be used instead of the default for retrieving public keys.