### PR TITLE
Sem-Ver: bugfix HTTPSPublicKeyRetriever should raise a ValueError if the base_url is None.

### DIFF
--- a/atlassian_jwt_auth/key.py
+++ b/atlassian_jwt_auth/key.py
@@ -59,7 +59,7 @@ class HTTPSPublicKeyRetriever(object):
     """
 
     def __init__(self, base_url):
-        if not base_url.startswith('https://'):
+        if base_url is None or not base_url.startswith('https://'):
             raise ValueError('The base url must start with https://')
         if not base_url.endswith('/'):
             base_url += '/'

--- a/atlassian_jwt_auth/tests/test_public_key_provider.py
+++ b/atlassian_jwt_auth/tests/test_public_key_provider.py
@@ -23,6 +23,13 @@ class BaseHTTPSPublicKeyRetrieverTest(object):
         with self.assertRaises(ValueError):
             retriever = HTTPSPublicKeyRetriever('http://example.com')
 
+    def test_https_public_key_retriever_does_not_support_none_url(self):
+        """ tests that HTTPSPublicKeyRetriever does not support None
+            base urls.
+        """
+        with self.assertRaises(ValueError):
+            retriever = HTTPSPublicKeyRetriever(None)
+
     def test_https_public_key_retriever_supports_https_url(self):
         """ tests that HTTPSPublicKeyRetriever supports https://
             base urls.


### PR DESCRIPTION


Signed-off-by: David Black <dblack@atlassian.com>