### PR TITLE
Allow to pass in additional claims to contrib.requests.JWTAuth

### DIFF
--- a/atlassian_jwt_auth/contrib/requests.py
+++ b/atlassian_jwt_auth/contrib/requests.py
@@ -17,13 +17,15 @@ class JWTAuth(AuthBase):
     """Adds a JWT bearer token to the request per the ASAP specification"""
 
     def __init__(self, signer, audience, *args, **kwargs):
-        super(JWTAuth, self).__init__(*args, **kwargs)
+        super(JWTAuth, self).__init__()
 
         self._audience = audience
         self._signer = signer
+        self._additional_claims = kwargs.get('additional_claims', {})
 
     def __call__(self, r):
         r.headers['Authorization'] = (
-            b'Bearer ' + self._signer.generate_jwt(self._audience)
+            b'Bearer ' + self._signer.generate_jwt(
+                self._audience, additional_claims=self._additional_claims)
         )
         return r


### PR DESCRIPTION
This PR contains a minor change to allow passing in additional claims via `**kwargs` to `contrib.requests.JWTAuth`. As far as I can tell, there is currently no other way to do this, unless I'm missing something. /cc @dbaxa 