### PR TITLE
Fix Python 3 issue with default value

### DIFF
--- a/atlassian_jwt_auth/contrib/django/decorators.py
+++ b/atlassian_jwt_auth/contrib/django/decorators.py
@@ -18,7 +18,7 @@ def requires_asap(issuers=None):
         @wraps(func)
         def requires_asap_wrapper(request, *args, **kwargs):
             verifier = _get_verifier()
-            auth = request.META.get('HTTP_AUTHORIZATION', '').split(b' ')
+            auth = request.META.get('HTTP_AUTHORIZATION', b'').split(b' ')
             if not auth or len(auth) != 2:
                 return HttpResponse('Unauthorized', status=401)
             error_message = None

--- a/atlassian_jwt_auth/contrib/tests/django/test_django.py
+++ b/atlassian_jwt_auth/contrib/tests/django/test_django.py
@@ -87,6 +87,13 @@ class TestAsapDecorator(RS256KeyTestMixin, SimpleTestCase):
         self.assertContains(response, 'Unauthorized: Invalid token',
                             status_code=401)
 
+    def test_request_without_token_is_rejected(self):
+        with override_settings(**self.test_settings):
+            response = self.client.get(reverse('expected'))
+
+        self.assertContains(response, 'Unauthorized',
+                            status_code=401)
+
     def test_request_with_invalid_issuer_is_rejected(self):
         retriever = get_static_retriever_class({
             'something-invalid/key01': self._public_key_pem


### PR DESCRIPTION
When using the default value in the `requires_asap` decorator, the
`split(b'')` call fails in Python 3 because bytes != str. This change just
sets the default value to a bytes instead of a str.