### PR TITLE
Add .mailmap to resolve some duplicate identities

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,4 @@
+David Black <dblack@atlassian.com> <dbaxa@users.noreply.github.com>
+David Black <dblack@atlassian.com> <dblack@atlassian.com>
+Mark Adams <madams@atlassian.com> <mark@markadams.me>
+Jeremy Shoemaker <jshoemaker@atlassian.com> <jeremy@codingkoi.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,10 +1,8 @@
 Cameron Stewart <cstewart@atlassian.com>
 David Black <dblack@atlassian.com>
-David Black [Atlassian] <dblack@atlassian.com>
 James Bunton <jbunton@atlassian.com>
-Jeremy Shoemaker <jeremy@codingkoi.com>
+Jeremy Shoemaker <jshoemaker@atlassian.com>
 Marcus Bertrand <digimarc@gmail.com>
 Mark Adams <madams@atlassian.com>
-Mark Adams <mark@markadams.me>
 Oleksandr Fedorov <a.g.fedorof@gmail.com>
 Waldemar Hummer <hummer@infosys.tuwien.ac.at>


### PR DESCRIPTION
Before:
```
$ git shortlog -s -e
     1  Cameron Stewart <cstewart@atlassian.com>
     6  David Black <dbaxa@users.noreply.github.com>
   158  David Black <dblack@atlassian.com>
     5  David Black [Atlassian] <dblack@atlassian.com>
     3  James Bunton <jbunton@atlassian.com>
     1  Jeremy Shoemaker <jeremy@codingkoi.com>
     2  Marcus Bertrand <digimarc@gmail.com>
     1  Mark Adams <madams@atlassian.com>
     4  Mark Adams <mark@markadams.me>
     1  Oleksandr Fedorov <a.g.fedorof@gmail.com>
     1  Waldemar Hummer <hummer@infosys.tuwien.ac.at>
```

After:
```
$ git shortlog -s -e
     1  Cameron Stewart <cstewart@atlassian.com>
   169  David Black <dblack@atlassian.com>
     3  James Bunton <jbunton@atlassian.com>
     1  Jeremy Shoemaker <jeremy@codingkoi.com>
     2  Marcus Bertrand <digimarc@gmail.com>
     7  Mark Adams <madams@atlassian.com>
     1  Oleksandr Fedorov <a.g.fedorof@gmail.com>
     1  Waldemar Hummer <hummer@infosys.tuwien.ac.at>
```