### PR TITLE
Fix for using requests library in Python 3

### DIFF
--- a/atlassian_jwt_auth/contrib/django/decorators.py
+++ b/atlassian_jwt_auth/contrib/django/decorators.py
@@ -2,8 +2,9 @@ from functools import wraps
 
 from django.conf import settings
 from django.http.response import HttpResponse
-from requests.exceptions import (HTTPError, ConnectionError)
+from django.utils import six
 from jwt.exceptions import (InvalidIssuerError, InvalidTokenError)
+from requests.exceptions import ConnectionError, HTTPError
 
 import atlassian_jwt_auth
 from .utils import parse_jwt, verify_issuers
@@ -18,7 +19,15 @@ def requires_asap(issuers=None):
         @wraps(func)
         def requires_asap_wrapper(request, *args, **kwargs):
             verifier = _get_verifier()
-            auth = request.META.get('HTTP_AUTHORIZATION', b'').split(b' ')
+            auth_header = request.META.get('HTTP_AUTHORIZATION', b'')
+            # Per PEP-3333, headers must be in ISO-8859-1 or use an RFC-2047
+            # MIME encoding. We don't really care about MIME encoded
+            # headers, but some libraries allow sending bytes (Django tests)
+            # and some (requests) always send str so we need to convert if
+            # that is the case to properly support Python 3.
+            if isinstance(auth_header, six.string_types):
+                auth_header = auth_header.encode(encoding='iso-8859-1')
+            auth = auth_header.split(b' ')
             if not auth or len(auth) != 2:
                 return HttpResponse('Unauthorized', status=401)
             error_message = None

--- a/atlassian_jwt_auth/contrib/tests/django/test_django.py
+++ b/atlassian_jwt_auth/contrib/tests/django/test_django.py
@@ -66,6 +66,19 @@ class TestAsapDecorator(RS256KeyTestMixin, SimpleTestCase):
 
         self.assertContains(response, 'Greatest Success!', status_code=200)
 
+    def test_request_with_string_headers_is_allowed(self):
+        token = create_token(
+            issuer='client-app', audience='server-app',
+            key_id='client-app/key01', private_key=self._private_key_pem
+        )
+        str_token = token.decode(encoding='iso-8859-1')
+        with override_settings(**self.test_settings):
+            response = self.client.get(reverse('expected'),
+                                       HTTP_AUTHORIZATION='Bearer ' +
+                                                          str_token)
+
+        self.assertContains(response, 'Greatest Success!', status_code=200)
+
     def test_request_with_invalid_audience_is_rejected(self):
         token = create_token(
             issuer='client-app', audience='something-invalid',


### PR DESCRIPTION
More issues with string encodings. The requests library seems to force
HTTP headers to be strings even if you give it a bytes so to deal with
that potential ambiguity, we should just explicitly convert any
strings we get in the HTTP_AUTHORIZATION header into bytes before
attempting to parse it further.