### PR TITLE
Sem-Ver: feature Add support for customising the value of the leeway …

### DIFF
--- a/atlassian_jwt_auth/contrib/django/utils.py
+++ b/atlassian_jwt_auth/contrib/django/utils.py
@@ -7,7 +7,7 @@ def parse_jwt(verifier, encoded_jwt):
     claims = verifier.verify_jwt(
         encoded_jwt,
         settings.ASAP_VALID_AUDIENCE,
-        leeway=60
+        leeway=getattr(settings, 'ASAP_VALID_LEEWAY', 0)
     )
     return claims
 

--- a/atlassian_jwt_auth/contrib/flask_app/utils.py
+++ b/atlassian_jwt_auth/contrib/flask_app/utils.py
@@ -7,7 +7,7 @@ def parse_jwt(verifier, encoded_jwt):
     claims = verifier.verify_jwt(
         encoded_jwt,
         current_app.config['ASAP_VALID_AUDIENCE'],
-        leeway=60
+        leeway=current_app.config.get('ASAP_VALID_LEEWAY', 0)
     )
 
     valid_issuers = current_app.config.get('ASAP_VALID_ISSUERS')


### PR DESCRIPTION
…used in the django and flask contrib code through the ASAP_VALID_LEEWAY setting.

Please note as part of this change the default leeway has been changed to 0 for consistency.

Signed-off-by: David Black <dblack@atlassian.com>