### PR TITLE
Make _seen_jti a ringbuffer.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,11 @@
 CHANGES
 =======
 
+2.11.2
+------
+
+* Sem-Ver: bugfix Fix the requires_asap decorator for python 3 by forcing the HTTP_AUTHORIZATION header into bytes before parsing it
+
 2.11.1
 ------
 

--- a/atlassian_jwt_auth/verifier.py
+++ b/atlassian_jwt_auth/verifier.py
@@ -1,4 +1,4 @@
-from collections import deque, OrderedDict
+from collections import OrderedDict
 
 import jwt
 

--- a/atlassian_jwt_auth/verifier.py
+++ b/atlassian_jwt_auth/verifier.py
@@ -1,3 +1,5 @@
+from collections import deque
+
 import jwt
 
 from atlassian_jwt_auth import algorithms
@@ -11,7 +13,7 @@ class JWTAuthVerifier(object):
     def __init__(self, public_key_retriever, **kwargs):
         self.public_key_retriever = public_key_retriever
         self.algorithms = algorithms.get_permitted_algorithm_names()
-        self._seen_jti = set()
+        self._seen_jti = deque(maxlen=1000)
         self._subject_should_match_issuer = kwargs.get(
             'subject_should_match_issuer', True)
 
@@ -72,7 +74,5 @@ class JWTAuthVerifier(object):
         if _jti in self._seen_jti:
             raise ValueError("The jti, '%s', has already been used." % _jti)
         else:
-            if len(self._seen_jti) > 100:
-                self._seen_jti = set()
-            self._seen_jti.add(_jti)
+            self._seen_jti.append(_jti)
         return claims

--- a/atlassian_jwt_auth/verifier.py
+++ b/atlassian_jwt_auth/verifier.py
@@ -1,4 +1,4 @@
-from collections import deque
+from collections import deque, OrderedDict
 
 import jwt
 
@@ -13,7 +13,7 @@ class JWTAuthVerifier(object):
     def __init__(self, public_key_retriever, **kwargs):
         self.public_key_retriever = public_key_retriever
         self.algorithms = algorithms.get_permitted_algorithm_names()
-        self._seen_jti = deque(maxlen=1000)
+        self._seen_jti = OrderedDict()
         self._subject_should_match_issuer = kwargs.get(
             'subject_should_match_issuer', True)
 
@@ -74,5 +74,7 @@ class JWTAuthVerifier(object):
         if _jti in self._seen_jti:
             raise ValueError("The jti, '%s', has already been used." % _jti)
         else:
-            self._seen_jti.append(_jti)
+            self._seen_jti[_jti] = None
+            while len(self._seen_jti) > 1000:
+                self._seen_jti.popitem(last=False)
         return claims


### PR DESCRIPTION
Throwing away the entire contents of the jti list when it reaches capacity seems undesirable. This change makes it a ringbuffer that automatically takes care of expunging old entries.

I've also increased the capacity.