### PR TITLE
Add multiple public key retriever support to library

### DIFF
--- a/atlassian_jwt_auth/contrib/aiohttp/key.py
+++ b/atlassian_jwt_auth/contrib/aiohttp/key.py
@@ -11,11 +11,11 @@ from atlassian_jwt_auth.key import (
 class HTTPSPublicKeyRetriever(_HTTPSPublicKeyRetriever):
     """A class for retrieving JWT public keys with aiohttp"""
 
-    def __init__(self, base_url, *, loop=None):
+    def __init__(self, base_urls, *, loop=None):
         if loop is None:
             loop = asyncio.get_event_loop()
         self.loop = loop
-        super().__init__(base_url)
+        super().__init__(base_urls)
 
     def _get_session(self):
         return aiohttp.ClientSession(loop=self.loop)

--- a/atlassian_jwt_auth/contrib/django/utils.py
+++ b/atlassian_jwt_auth/contrib/django/utils.py
@@ -23,4 +23,5 @@ def verify_issuers(asap_claims, issuers=None):
     valid_issuers = settings.ASAP_VALID_ISSUERS
     if valid_issuers and claim_iss not in valid_issuers:
         raise InvalidIssuerError(
-            'Issuer `%s` not in valid issuers for this application' % claim_iss)
+            'Issuer `%s` not in valid issuers for this application'
+            % claim_iss)

--- a/atlassian_jwt_auth/contrib/django/utils.py
+++ b/atlassian_jwt_auth/contrib/django/utils.py
@@ -14,9 +14,13 @@ def parse_jwt(verifier, encoded_jwt):
 
 def verify_issuers(asap_claims, issuers=None):
     """Verify that the issuer in the claims is valid and is expected."""
-    if issuers and (asap_claims.get('iss') not in issuers):
+    claim_iss = asap_claims.get('iss')
+
+    if issuers and (claim_iss not in issuers):
         # Raise early if the specific issuer isn't expected
-        raise InvalidIssuerError()
+        raise InvalidIssuerError(
+            'Issuer `%s` not in valid issuers for this endpoint' % claim_iss)
     valid_issuers = settings.ASAP_VALID_ISSUERS
-    if valid_issuers and asap_claims.get('iss') not in valid_issuers:
-        raise InvalidIssuerError()
+    if valid_issuers and claim_iss not in valid_issuers:
+        raise InvalidIssuerError(
+            'Issuer `%s` not in valid issuers for this application' % claim_iss)

--- a/atlassian_jwt_auth/contrib/tests/django/test_django.py
+++ b/atlassian_jwt_auth/contrib/tests/django/test_django.py
@@ -88,7 +88,7 @@ class TestAsapDecorator(RS256KeyTestMixin, SimpleTestCase):
             response = self.client.get(reverse('expected'),
                                        HTTP_AUTHORIZATION=b'Bearer ' + token)
 
-        self.assertContains(response, 'Unauthorized: Invalid token',
+        self.assertContains(response, 'Unauthorized: Invalid audience',
                             status_code=401)
 
     def test_request_with_invalid_token_is_rejected(self):
@@ -97,7 +97,7 @@ class TestAsapDecorator(RS256KeyTestMixin, SimpleTestCase):
                 reverse('expected'),
                 HTTP_AUTHORIZATION=b'Bearer notavalidtoken')
 
-        self.assertContains(response, 'Unauthorized: Invalid token',
+        self.assertContains(response, 'Unauthorized: Not enough segments',
                             status_code=401)
 
     def test_request_without_token_is_rejected(self):
@@ -119,7 +119,9 @@ class TestAsapDecorator(RS256KeyTestMixin, SimpleTestCase):
             response = self.client.get(reverse('expected'),
                                        HTTP_AUTHORIZATION=b'Bearer ' + token)
 
-        self.assertContains(response, 'Unauthorized: Invalid token issuer',
+        self.assertContains(response,
+                            'Unauthorized: Issuer `something-invalid` not in'
+                            ' valid issuers for this endpoint',
                             status_code=401)
 
     def test_request_non_whitelisted_decorated_issuer_is_rejected(self):
@@ -135,7 +137,9 @@ class TestAsapDecorator(RS256KeyTestMixin, SimpleTestCase):
             response = self.client.get(reverse('unexpected'),
                                        HTTP_AUTHORIZATION=b'Bearer ' + token)
 
-        self.assertContains(response, 'Unauthorized: Invalid token issuer',
+        self.assertContains(response,
+                            'Unauthorized: Issuer `unexpected` not in'
+                            ' valid issuers for this application',
                             status_code=401)
 
     def test_request_non_decorated_issuer_is_rejected(self):
@@ -147,7 +151,9 @@ class TestAsapDecorator(RS256KeyTestMixin, SimpleTestCase):
             response = self.client.get(reverse('decorated'),
                                        HTTP_AUTHORIZATION=b'Bearer ' + token)
 
-        self.assertContains(response, 'Unauthorized: Invalid token issuer',
+        self.assertContains(response,
+                            'Unauthorized: Issuer `client-app` not in valid'
+                            ' issuers for this endpoint',
                             status_code=401)
 
     def test_request_decorated_issuer_is_allowed(self):

--- a/atlassian_jwt_auth/exceptions.py
+++ b/atlassian_jwt_auth/exceptions.py
@@ -1,0 +1,18 @@
+class ASAPAuthenticationException(ValueError):
+    """Base class for exceptions raised by this library
+
+    Inherits from ValueError to maintain backward compatibility
+    with clients that caught ValueError previously.
+    """
+
+
+class PublicKeyRetrieverException(ASAPAuthenticationException):
+    """Raise when there are issues retrieving the public key"""
+
+
+class PrivateKeyRetrieverException(ASAPAuthenticationException):
+    """Raise when there are issues retrieving the private key"""
+
+
+class KeyIdentifierException(ASAPAuthenticationException):
+    """Raise when there are issues validating the key identifier"""

--- a/atlassian_jwt_auth/key.py
+++ b/atlassian_jwt_auth/key.py
@@ -6,9 +6,14 @@ import sys
 
 import cachecontrol
 import cryptography.hazmat.backends
-from cryptography.hazmat.primitives import serialization
 import jwt
 import requests
+from cryptography.hazmat.primitives import serialization
+from requests.exceptions import RequestException
+
+from atlassian_jwt_auth.exceptions import (PublicKeyRetrieverException,
+                                           PrivateKeyRetrieverException,
+                                           KeyIdentifierException)
 
 if sys.version_info[0] >= 3:
     from urllib.parse import unquote_plus
@@ -35,16 +40,16 @@ def validate_key_identifier(identifier):
     regex = re.compile('^[\w.\-\+/]*$')
     _error_msg = 'Invalid key identifier %s' % identifier
     if not identifier:
-        raise ValueError(_error_msg)
+        raise KeyIdentifierException(_error_msg)
     if not regex.match(identifier):
-        raise ValueError(_error_msg)
+        raise KeyIdentifierException(_error_msg)
     normalised = os.path.normpath(identifier)
     if normalised != identifier:
-        raise ValueError(_error_msg)
+        raise KeyIdentifierException(_error_msg)
     if normalised.startswith('/'):
-        raise ValueError(_error_msg)
+        raise KeyIdentifierException(_error_msg)
     if '..' in normalised:
-        raise ValueError(_error_msg)
+        raise KeyIdentifierException(_error_msg)
     return identifier
 
 
@@ -55,32 +60,36 @@ def _get_key_id_from_jwt_header(a_jwt):
 
 
 class HTTPSPublicKeyRetriever(object):
+    """Retrieves public key from https location(s) based on the given key id.
 
-    """ This class retrieves public key from a (set of) https location(s) based upon the
-         given key id.
+    :param str base_urls: A string containing a single url OR a list of url(s)
     """
 
     def __init__(self, base_urls):
-        if isinstance(base_urls, basestring):
+        if isinstance(base_urls, str):
             base_urls = [base_urls]
 
         if base_urls is None:
-            raise ValueError('Base URL list cannot be None')
+            raise PublicKeyRetrieverException('Base URL list cannot be None')
 
         if len(base_urls) < 1:
-            raise ValueError('At least one base URL must be provided')
+            raise PublicKeyRetrieverException(
+                'At least one base URL must be provided')
 
         self.base_urls = []
         for urlpart in base_urls:
-            if urlpart is None or not isinstance(urlpart, basestring):
-                raise ValueError('Base URLs must be strings')
+            if urlpart is None or not isinstance(urlpart, str):
+                raise PublicKeyRetrieverException('Base URLs must be strings')
+
             for url in urlpart.split('|'):
                 url = url.strip()
                 if not url.startswith('https://'):
-                    raise ValueError('All base urls must start with https://')
+                    raise PublicKeyRetrieverException(
+                        'All base urls must start with https://')
                 if not url.endswith('/'):
                     url += '/'
                 self.base_urls.append(url)
+
         self._session = self._get_session()
 
     def _get_session(self):
@@ -98,9 +107,9 @@ class HTTPSPublicKeyRetriever(object):
             url = base_url + key_identifier.key_id
             try:
                 return self._retrieve(url, requests_kwargs)
-            except Exception, e:
+            except RequestException as e:
                 exceptions.append(e)
-        raise ValueError('Encountered failures: %s', ','.join([str(x) for x in exceptions]))
+        raise PublicKeyRetrieverException(exceptions)
 
     def _retrieve(self, url, requests_kwargs):
         resp = self._session.get(url, headers={'accept': PEM_FILE_TYPE},
@@ -113,8 +122,9 @@ class HTTPSPublicKeyRetriever(object):
         media_type = cgi.parse_header(content_type)[0]
 
         if media_type.lower() != PEM_FILE_TYPE.lower():
-            raise ValueError("Invalid content-type, '%s', for url '%s' ." %
-                             (content_type, url))
+            raise PublicKeyRetrieverException(
+                "Invalid content-type, '%s', for url '%s' ." %
+                (content_type, url))
 
 
 class BasePrivateKeyRetriever(object):
@@ -137,7 +147,7 @@ class DataUriPrivateKeyRetriever(BasePrivateKeyRetriever):
 
     def load(self, issuer):
         if not self._data_uri.startswith('data:application/pkcs8;kid='):
-            raise ValueError('Unrecognised data uri format.')
+            raise PrivateKeyRetrieverException('Unrecognised data uri format.')
         splitted = self._data_uri.split(';')
         key_identifier = KeyIdentifier(unquote_plus(
             splitted[1][len('kid='):]))

--- a/atlassian_jwt_auth/tests/test_key.py
+++ b/atlassian_jwt_auth/tests/test_key.py
@@ -1,6 +1,7 @@
 import unittest
 
 import atlassian_jwt_auth
+from atlassian_jwt_auth.exceptions import KeyIdentifierException
 
 
 class TestKeyModule(unittest.TestCase):
@@ -14,7 +15,7 @@ class TestKeyModule(unittest.TestCase):
                 u'dir/some\0thing', 'a/#a', 'a/a?x', 'a/a;',
                 ]
         for key in keys:
-            with self.assertRaises(ValueError):
+            with self.assertRaises(KeyIdentifierException):
                 atlassian_jwt_auth.KeyIdentifier(identifier=key)
 
     def test_key_identifier_with_valid_keys(self):

--- a/atlassian_jwt_auth/tests/test_public_key_provider.py
+++ b/atlassian_jwt_auth/tests/test_public_key_provider.py
@@ -15,6 +15,7 @@ class BaseHTTPSPublicKeyRetrieverTest(object):
         self._public_key_pem = utils.get_public_key_pem_for_private_key_pem(
             self._private_key_pem)
         self.base_url = 'https://example.com'
+        self.second_base_url = 'https://2.example.com'
 
     def test_https_public_key_retriever_does_not_support_http_url(self):
         """ tests that HTTPSPublicKeyRetriever does not support http://
@@ -35,6 +36,19 @@ class BaseHTTPSPublicKeyRetrieverTest(object):
             base urls.
         """
         retriever = HTTPSPublicKeyRetriever(self.base_url)
+
+    def test_https_public_key_retriever_supports_multiple_https_urls(self):
+        """ tests that HTTPSPublicKeyRetriever supports multiple https://
+            base urls.
+        """
+        retriever = HTTPSPublicKeyRetriever([self.base_url, self.second_base_url])
+
+    def test_https_public_key_retriever_supports_pipe_notation_https_urls(self):
+        """ tests that HTTPSPublicKeyRetriever supports URLs containing pipes
+            denoting multiple base urls.
+        """
+        retriever = HTTPSPublicKeyRetriever([self.base_url + '|' + self.second_base_url])
+        self.assertEqual(2, len(retriever.base_urls))
 
     @mock.patch.object(requests.Session, 'get')
     def test_retrieve(self, mock_get_method):

--- a/atlassian_jwt_auth/tests/test_public_key_provider.py
+++ b/atlassian_jwt_auth/tests/test_public_key_provider.py
@@ -42,13 +42,15 @@ class BaseHTTPSPublicKeyRetrieverTest(object):
         """ tests that HTTPSPublicKeyRetriever supports multiple https://
             base urls.
         """
-        retriever = HTTPSPublicKeyRetriever([self.base_url, self.second_base_url])
+        retriever = HTTPSPublicKeyRetriever(
+            [self.base_url, self.second_base_url])
 
-    def test_https_public_key_retriever_supports_pipe_notation_https_urls(self):
+    def test_https_public_key_retriever_supports_pipe_notation_urls(self):
         """ tests that HTTPSPublicKeyRetriever supports URLs containing pipes
             denoting multiple base urls.
         """
-        retriever = HTTPSPublicKeyRetriever([self.base_url + '|' + self.second_base_url])
+        retriever = HTTPSPublicKeyRetriever(
+            [self.base_url + '|' + self.second_base_url])
         self.assertEqual(2, len(retriever.base_urls))
 
     @mock.patch.object(requests.Session, 'get')

--- a/atlassian_jwt_auth/tests/test_public_key_provider.py
+++ b/atlassian_jwt_auth/tests/test_public_key_provider.py
@@ -3,6 +3,7 @@ import unittest
 import mock
 import requests
 
+from atlassian_jwt_auth.exceptions import PublicKeyRetrieverException
 from atlassian_jwt_auth.key import HTTPSPublicKeyRetriever
 from atlassian_jwt_auth.tests import utils
 
@@ -21,14 +22,14 @@ class BaseHTTPSPublicKeyRetrieverTest(object):
         """ tests that HTTPSPublicKeyRetriever does not support http://
             base urls.
         """
-        with self.assertRaises(ValueError):
+        with self.assertRaises(PublicKeyRetrieverException):
             retriever = HTTPSPublicKeyRetriever('http://example.com')
 
     def test_https_public_key_retriever_does_not_support_none_url(self):
         """ tests that HTTPSPublicKeyRetriever does not support None
             base urls.
         """
-        with self.assertRaises(ValueError):
+        with self.assertRaises(PublicKeyRetrieverException):
             retriever = HTTPSPublicKeyRetriever(None)
 
     def test_https_public_key_retriever_supports_https_url(self):
@@ -82,7 +83,7 @@ class BaseHTTPSPublicKeyRetrieverTest(object):
         _setup_mock_response_for_retriever(
             mock_get_method, self._public_key_pem, headers)
         retriever = HTTPSPublicKeyRetriever(self.base_url)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(PublicKeyRetrieverException):
             retriever.retrieve('example/eg')
 
 


### PR DESCRIPTION
Thanks to BJacobs for the base work here. I took it the rest of the way to make sure it works with Python2-3 as well as make some of the exception raising and handling a bit more pythonic. I also added a lot more information and logging to the decorator for Django. This required changing some expected test output.