### PR TITLE
Add library exceptions instead of using ValueError

### DIFF
--- a/atlassian_jwt_auth/contrib/django/decorators.py
+++ b/atlassian_jwt_auth/contrib/django/decorators.py
@@ -12,8 +12,6 @@ from atlassian_jwt_auth.exceptions import (PrivateKeyRetrieverException,
                                            PublicKeyRetrieverException)
 from .utils import parse_jwt, verify_issuers
 
-logger = logging.getLogger(__name__)
-
 
 def requires_asap(issuers=None):
     """Decorator for Django endpoints to require ASAP
@@ -57,6 +55,7 @@ def requires_asap(issuers=None):
                 # Something went wrong with decoding the JWT
                 exception = ('Unauthorized: Invalid token', e)
             if exception is not None:
+                logger = logging.getLogger(__name__)
                 logger.error(exception[0],
                              extra={'original_message': str(exception[1])})
 

--- a/atlassian_jwt_auth/contrib/django/decorators.py
+++ b/atlassian_jwt_auth/contrib/django/decorators.py
@@ -1,7 +1,5 @@
 import logging
-from collections import namedtuple
 from functools import wraps
-from typing import NamedTuple
 
 from django.conf import settings
 from django.http.response import HttpResponse

--- a/atlassian_jwt_auth/contrib/django/utils.py
+++ b/atlassian_jwt_auth/contrib/django/utils.py
@@ -1,5 +1,10 @@
+import logging
+
 from django.conf import settings
 from jwt.exceptions import InvalidIssuerError
+
+
+logger = logging.getLogger(__name__)
 
 
 def parse_jwt(verifier, encoded_jwt):
@@ -14,9 +19,19 @@ def parse_jwt(verifier, encoded_jwt):
 
 def verify_issuers(asap_claims, issuers=None):
     """Verify that the issuer in the claims is valid and is expected."""
-    if issuers and (asap_claims.get('iss') not in issuers):
+    claim_iss = asap_claims.get('iss')
+
+    if issuers and (claim_iss not in issuers):
         # Raise early if the specific issuer isn't expected
-        raise InvalidIssuerError()
+        message = 'Issuer not in valid issuers for this endpoint'
+        logger.error(message, extra={'iss': claim_iss})
+
+        raise InvalidIssuerError(message)
+
     valid_issuers = settings.ASAP_VALID_ISSUERS
-    if valid_issuers and asap_claims.get('iss') not in valid_issuers:
-        raise InvalidIssuerError()
+    if valid_issuers and claim_iss not in valid_issuers:
+        message = 'Issuer not in valid issuers for this application'
+        logger.error(message, extra={'iss': claim_iss})
+
+        raise InvalidIssuerError(message)
+

--- a/atlassian_jwt_auth/contrib/django/utils.py
+++ b/atlassian_jwt_auth/contrib/django/utils.py
@@ -4,9 +4,6 @@ from django.conf import settings
 from jwt.exceptions import InvalidIssuerError
 
 
-logger = logging.getLogger(__name__)
-
-
 def parse_jwt(verifier, encoded_jwt):
     """Decode an encoded JWT using stored config."""
     claims = verifier.verify_jwt(
@@ -20,6 +17,7 @@ def parse_jwt(verifier, encoded_jwt):
 def verify_issuers(asap_claims, issuers=None):
     """Verify that the issuer in the claims is valid and is expected."""
     claim_iss = asap_claims.get('iss')
+    logger = logging.getLogger(__name__)
 
     if issuers and (claim_iss not in issuers):
         # Raise early if the specific issuer isn't expected

--- a/atlassian_jwt_auth/contrib/django/utils.py
+++ b/atlassian_jwt_auth/contrib/django/utils.py
@@ -34,4 +34,3 @@ def verify_issuers(asap_claims, issuers=None):
         logger.error(message, extra={'iss': claim_iss})
 
         raise InvalidIssuerError(message)
-

--- a/atlassian_jwt_auth/exceptions.py
+++ b/atlassian_jwt_auth/exceptions.py
@@ -1,0 +1,18 @@
+class ASAPAuthenticationException(ValueError):
+    """Base class for exceptions raised by this library
+
+    Inherits from ValueError to maintain backward compatibility
+    with clients that caught ValueError previously.
+    """
+
+
+class PublicKeyRetrieverException(ASAPAuthenticationException):
+    """Raise when there are issues retrieving the public key"""
+
+
+class PrivateKeyRetrieverException(ASAPAuthenticationException):
+    """Raise when there are issues retrieving the private key"""
+
+
+class KeyIdentifierException(ASAPAuthenticationException):
+    """Raise when there are issues validating the key identifier"""


### PR DESCRIPTION
This also maintains backwards compatibility with existing clients
by keeping ValueError as the base exception.

I also added some logging for Django, but not opposed to splitting that out too.