### PR TITLE
Sem-Ver: bugfix upgrade cryptography from using a version >= 1.8.1 < 1.9.0 to use a version >= 2.0.3 and < 2.1.0.

### DIFF
--- a/atlassian_jwt_auth/contrib/tests/test_requests.py
+++ b/atlassian_jwt_auth/contrib/tests/test_requests.py
@@ -26,8 +26,9 @@ class BaseRequestsTest(object):
         bearer = auth_header.split(b' ')[1]
         # Decode the JWT (verifying the signature and aud match)
         # an exception is thrown if this fails
+        algorithms = atlassian_jwt_auth.get_permitted_algorithm_names()
         return jwt.decode(bearer, self._public_key_pem.decode(),
-                          audience='audience')
+                          audience='audience', algorithms=algorithms)
 
     def _get_auth_header(self, auth):
         request = auth(Request())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cryptography>=1.8.1,<1.9.0
+cryptography>=2.0.3,<2.1.0
 PyJWT>=1.5.2,<2.0.0
 requests>=2.8.1,<3.0.0
 CacheControl==0.12.1


### PR DESCRIPTION

Signed-off-by: David Black <dblack@atlassian.com>