### PR TITLE
Make _seen_jti a ringbuffer.

### DIFF
--- a/atlassian_jwt_auth/verifier.py
+++ b/atlassian_jwt_auth/verifier.py
@@ -1,3 +1,5 @@
+from collections import OrderedDict
+
 import jwt
 
 from atlassian_jwt_auth import algorithms
@@ -11,7 +13,7 @@ class JWTAuthVerifier(object):
     def __init__(self, public_key_retriever, **kwargs):
         self.public_key_retriever = public_key_retriever
         self.algorithms = algorithms.get_permitted_algorithm_names()
-        self._seen_jti = set()
+        self._seen_jti = OrderedDict()
         self._subject_should_match_issuer = kwargs.get(
             'subject_should_match_issuer', True)
 
@@ -72,7 +74,7 @@ class JWTAuthVerifier(object):
         if _jti in self._seen_jti:
             raise ValueError("The jti, '%s', has already been used." % _jti)
         else:
-            if len(self._seen_jti) > 100:
-                self._seen_jti = set()
-            self._seen_jti.add(_jti)
+            self._seen_jti[_jti] = None
+            while len(self._seen_jti) > 1000:
+                self._seen_jti.popitem(last=False)
         return claims


### PR DESCRIPTION
Switched to an OrderedDict to reduce jti lookups from n to log(n).

(cherry picked from commit 39296ce9231c9c51a7f8840afa3c6eb86ea0c213)
Signed-off-by: David Black <dblack@atlassian.com>