### PR TITLE
Add validate_asap()

### DIFF
--- a/atlassian_jwt_auth/contrib/django/decorators.py
+++ b/atlassian_jwt_auth/contrib/django/decorators.py
@@ -1,5 +1,6 @@
 import logging
 from functools import wraps
+import warnings
 
 from django.conf import settings
 from django.http.response import HttpResponse
@@ -58,8 +59,13 @@ def requires_asap(issuers=None):
     """Decorator for Django endpoints to require ASAP
 
     :param list issuers: *required The 'iss' claims that this endpoint is from.
+
+    DEPRECATED: use ASAPMiddleware and validate_asap instead.
     """
     def requires_asap_decorator(func):
+        warnings.warn("requires_asap is deprecated; use ASAPMiddleware and "
+                      "validate_asap instead.", DeprecationWarning)
+
         @wraps(func)
         def requires_asap_wrapper(request, *args, **kwargs):
             verifier = _get_verifier()

--- a/atlassian_jwt_auth/contrib/django/decorators.py
+++ b/atlassian_jwt_auth/contrib/django/decorators.py
@@ -13,6 +13,47 @@ from atlassian_jwt_auth.exceptions import (PrivateKeyRetrieverException,
 from .utils import parse_jwt, verify_issuers
 
 
+def validate_asap(issuers=None, subjects=None, required=True):
+    """Decorator to allow endpoint-specific ASAP validation.
+
+    :param list issuers: A list of issuers that are allowed to use the
+        endpoint.
+    :param subject: A list of subjects or a function to determine allowed
+        subjects for the endpoint.
+    :param boolean required: Whether or not to require ASAP on this endpoint.
+        Note that requirements will be still be verified if claims are present.
+    """
+    def validate_asap_decorator(func):
+        @wraps(func)
+        def validate_asap_wrapper(request, *args, **kwargs):
+            asap_claims = getattr(request, 'asap_claims', {})
+            if required and not asap_claims:
+                message = 'Unauthorized: Invalid or missing token'
+                return HttpResponse(message, status=401)
+
+            iss = asap_claims.get('iss')
+            if issuers and iss not in issuers:
+                message = 'Unauthorized: Invalid token issuer'
+                return HttpResponse(message, status=401)
+
+            sub = asap_claims.get('sub')
+            if callable(subjects):
+                sub_allowed = subjects(sub)
+            elif isinstance(subjects, list):
+                sub_allowed = sub in subjects
+            else:
+                sub_allowed = True
+
+            if not sub_allowed:
+                message = 'Unauthorized: Invalid token subject'
+                return HttpResponse(message, status=401)
+
+            return func(request, *args, **kwargs)
+
+        return validate_asap_wrapper
+    return validate_asap_decorator
+
+
 def requires_asap(issuers=None):
     """Decorator for Django endpoints to require ASAP
 

--- a/atlassian_jwt_auth/contrib/django/decorators.py
+++ b/atlassian_jwt_auth/contrib/django/decorators.py
@@ -45,8 +45,8 @@ def validate_asap(issuers=None, subjects=None, required=True):
                 sub_allowed = True
 
             if not sub_allowed:
-                message = 'Unauthorized: Invalid token subject'
-                return HttpResponse(message, status=401)
+                message = 'Forbidden: Invalid token subject'
+                return HttpResponse(message, status=403)
 
             return func(request, *args, **kwargs)
 


### PR DESCRIPTION
The requires_asap() decorator runs performs all the auth itself, which in Django means that the request must successfully pass through all the middleware before hitting the view. This is good for per-view ASAP validation, but bad for working with other middleware.

The validate_asap() decorator assumes some middleware will check that the ASAP token is valid for the application, and put any resulting claims in request.asap_claims to allow per-endpoint authorization.