### PR TITLE
Add ASAPMiddleware

### DIFF
--- a/atlassian_jwt_auth/contrib/django/middleware.py
+++ b/atlassian_jwt_auth/contrib/django/middleware.py
@@ -1,4 +1,14 @@
+import logging
+
+from jwt import InvalidAudienceError
+
 from django.conf import settings
+from django.http.response import HttpResponse
+from django.utils import six
+from jwt.exceptions import InvalidTokenError
+
+import atlassian_jwt_auth
+from .utils import parse_jwt, verify_issuers
 
 
 class ASAPForwardedMiddleware(object):
@@ -53,3 +63,75 @@ class ASAPForwardedMiddleware(object):
             request.META['HTTP_AUTHORIZATION'] = asap_auth
         if orig_auth is not None:
             request.META[self.xauth] = orig_auth
+
+
+class ASAPMiddleware(ASAPForwardedMiddleware):
+    """Enable ASAP for Django applications.
+
+    To use proxied credentials, this must come before any authentication
+    middleware.
+    """
+
+    def __init__(self, get_response=None):
+        super(ASAPMiddleware, self).__init__(get_response=get_response)
+
+        self.logger = logging.getLogger(__name__)
+
+        self.required = getattr(settings, 'ASAP_REQUIRED', True)
+        self.client_auth = getattr(settings, 'ASAP_CLIENT_AUTH', False)
+
+        # Configure verifier based on settings
+        retriever_kwargs = {}
+        retriever_cls = getattr(settings, 'ASAP_KEY_RETRIEVER_CLASS',
+                                atlassian_jwt_auth.HTTPSPublicKeyRetriever)
+        public_key_url = getattr(settings, 'ASAP_PUBLICKEY_REPOSITORY', None)
+        if public_key_url:
+            retriever_kwargs['base_url'] = public_key_url
+        retriever = retriever_cls(**retriever_kwargs)
+        self.verifier = atlassian_jwt_auth.JWTAuthVerifier(retriever)
+
+    def process_request(self, request):
+        auth_header = request.META.get('HTTP_AUTHORIZATION', b'')
+        # Per PEP-3333, headers must be in ISO-8859-1 or use an RFC-2047
+        # MIME encoding. We don't really care about MIME encoded
+        # headers, but some libraries allow sending bytes (Django tests)
+        # and some (requests) always send str so we need to convert if
+        # that is the case to properly support Python 3.
+        if isinstance(auth_header, six.string_types):
+            auth_header = auth_header.encode(encoding='iso-8859-1')
+        try:
+            scheme, auth = auth_header.split(b' ')
+        except ValueError:
+            scheme = b''
+
+        if scheme.lower() != b'bearer':
+            if not self.required:
+                return
+            message = 'Unauthorized: Invalid or missing token'
+            return HttpResponse(message, status=401)
+
+        try:
+            asap_claims = parse_jwt(self.verifier, auth)
+            verify_issuers(asap_claims)
+        except InvalidAudienceError as e:
+            if not self.required:
+                return
+            message = 'Forbidden: %s' % e
+            return HttpResponse(message, status=403)
+        except InvalidTokenError as e:
+            if not self.required:
+                return
+            message = 'Unauthorized: %s' % e
+            return HttpResponse(message, status=401)
+        except Exception as e:
+            # Something is rotten in the state of ASAP
+            self.logger.error(message,
+                              extra={'original_message': str(e)})
+            if not self.required:
+                return
+            raise
+
+        request.asap_claims = asap_claims
+
+        if self.client_auth:
+            super(ASAPMiddleware, self).process_request(request)

--- a/atlassian_jwt_auth/contrib/django/middleware.py
+++ b/atlassian_jwt_auth/contrib/django/middleware.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 
 from jwt import InvalidAudienceError
 
@@ -16,9 +17,14 @@ class ASAPForwardedMiddleware(object):
     non-ASAP client requests.
 
     This must come before any authentication middleware.
+
+    DEPRECATED: use ASAPMiddleware instead.
     """
 
     def __init__(self, get_response=None):
+        warnings.warn("ASAPForwardedMiddleware is deprecated; use "
+                      "ASAPMiddleware instead", DeprecationWarning)
+
         self.get_response = get_response
 
         # Rely on this header to tell us if a request has been forwarded
@@ -73,7 +79,8 @@ class ASAPMiddleware(ASAPForwardedMiddleware):
     """
 
     def __init__(self, get_response=None):
-        super(ASAPMiddleware, self).__init__(get_response=get_response)
+        with warnings.catch_warnings():
+            super(ASAPMiddleware, self).__init__(get_response=get_response)
 
         self.logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Django usually performs authentication in middleware, so that's where we should put ASAP-based authentication.

This is also an opportunity to fix an issue with ASAPForwardedMiddleware, which will unintuitively run other middleware-based authentication before any ASAP authentication.