### PR TITLE
Add better Django ASAP middleware

### DIFF
--- a/atlassian_jwt_auth/contrib/django/decorators.py
+++ b/atlassian_jwt_auth/contrib/django/decorators.py
@@ -14,8 +14,8 @@ def validate_asap(issuers=None, subjects=None, required=True):
 
     :param list issuers: A list of issuers that are allowed to use the
         endpoint.
-    :param subject: A list of subjects or a function to determine allowed
-        subjects for the endpoint.
+    :param list subjects: A list of subjects that are allowed to use the
+        endpoint.
     :param boolean required: Whether or not to require ASAP on this endpoint.
         Note that requirements will be still be verified if claims are present.
     """
@@ -36,14 +36,7 @@ def validate_asap(issuers=None, subjects=None, required=True):
                     return HttpResponse(message, status=403)
 
                 sub = asap_claims.get('sub')
-                if callable(subjects):
-                    sub_allowed = subjects(sub)
-                elif hasattr(subjects, '__contains__'):
-                    sub_allowed = sub in subjects
-                else:
-                    sub_allowed = True
-
-                if not sub_allowed:
+                if subjects and sub not in subjects:
                     message = 'Forbidden: Invalid token subject'
                     return HttpResponse(message, status=403)
 

--- a/atlassian_jwt_auth/contrib/django/decorators.py
+++ b/atlassian_jwt_auth/contrib/django/decorators.py
@@ -1,10 +1,9 @@
 from functools import wraps
 
 from django.conf import settings
-from django.http.response import HttpResponse
 
 import atlassian_jwt_auth
-from .utils import parse_jwt, verify_issuers
+from .utils import parse_jwt, verify_issuers, _build_response
 from ..server.helpers import _requires_asap
 
 
@@ -43,14 +42,3 @@ def _get_verifier():
         base_url=getattr(settings, 'ASAP_PUBLICKEY_REPOSITORY')
     )
     return atlassian_jwt_auth.JWTAuthVerifier(retriever)
-
-
-def _build_response(message, status, headers=None):
-        if headers is None:
-            headers = {}
-
-        response = HttpResponse(message, status=status)
-        for header, value in headers.items():
-            response[header] = value
-
-        return response

--- a/atlassian_jwt_auth/contrib/django/middleware.py
+++ b/atlassian_jwt_auth/contrib/django/middleware.py
@@ -1,5 +1,3 @@
-import warnings
-
 from django.conf import settings
 
 import atlassian_jwt_auth
@@ -17,9 +15,6 @@ class ASAPForwardedMiddleware(object):
     """
 
     def __init__(self, get_response=None):
-        warnings.warn("ASAPForwardedMiddleware is deprecated; use "
-                      "ASAPMiddleware instead", DeprecationWarning)
-
         self.get_response = get_response
 
         # Rely on this header to tell us if a request has been forwarded
@@ -76,9 +71,7 @@ class ASAPMiddleware(ASAPForwardedMiddleware):
     """
 
     def __init__(self, get_response=None):
-        with warnings.catch_warnings():
-            super(ASAPMiddleware, self).__init__(get_response=get_response)
-
+        super(ASAPMiddleware, self).__init__(get_response=get_response)
         self.required = getattr(settings, 'ASAP_REQUIRED', True)
         self.client_auth = getattr(settings, 'ASAP_CLIENT_AUTH', False)
 

--- a/atlassian_jwt_auth/contrib/django/middleware.py
+++ b/atlassian_jwt_auth/contrib/django/middleware.py
@@ -21,7 +21,9 @@ class ASAPForwardedMiddleware(object):
                              'HTTP_X_ASAP_AUTHORIZATION')
 
     def __call__(self, request):
-        self.process_request(request)
+        early_response = self.process_request(request)
+        if early_response:
+            return early_response
         return self.get_response(request)
 
     def process_request(self, request):

--- a/atlassian_jwt_auth/contrib/django/middleware.py
+++ b/atlassian_jwt_auth/contrib/django/middleware.py
@@ -1,3 +1,5 @@
+import warnings
+
 from django.conf import settings
 
 import atlassian_jwt_auth
@@ -10,9 +12,14 @@ class ASAPForwardedMiddleware(object):
     non-ASAP client requests.
 
     This must come before any authentication middleware.
+
+    DEPRECATED: use ASAPMiddleware instead.
     """
 
     def __init__(self, get_response=None):
+        warnings.warn("ASAPForwardedMiddleware is deprecated; use "
+                      "ASAPMiddleware instead", DeprecationWarning)
+
         self.get_response = get_response
 
         # Rely on this header to tell us if a request has been forwarded
@@ -69,7 +76,8 @@ class ASAPMiddleware(ASAPForwardedMiddleware):
     """
 
     def __init__(self, get_response=None):
-        super(ASAPMiddleware, self).__init__(get_response=get_response)
+        with warnings.catch_warnings():
+            super(ASAPMiddleware, self).__init__(get_response=get_response)
 
         self.required = getattr(settings, 'ASAP_REQUIRED', True)
         self.client_auth = getattr(settings, 'ASAP_CLIENT_AUTH', False)

--- a/atlassian_jwt_auth/contrib/django/utils.py
+++ b/atlassian_jwt_auth/contrib/django/utils.py
@@ -36,11 +36,11 @@ def verify_issuers(asap_claims, issuers=None):
 
 
 def _build_response(message, status, headers=None):
-        if headers is None:
-            headers = {}
+    if headers is None:
+        headers = {}
 
-        response = HttpResponse(message, status=status)
-        for header, value in headers.items():
-            response[header] = value
+    response = HttpResponse(message, status=status)
+    for header, value in headers.items():
+        response[header] = value
 
-        return response
+    return response

--- a/atlassian_jwt_auth/contrib/django/utils.py
+++ b/atlassian_jwt_auth/contrib/django/utils.py
@@ -1,6 +1,7 @@
 import logging
 
 from django.conf import settings
+from django.http.response import HttpResponse
 from jwt.exceptions import InvalidIssuerError
 
 
@@ -32,3 +33,14 @@ def verify_issuers(asap_claims, issuers=None):
         logger.error(message, extra={'iss': claim_iss})
 
         raise InvalidIssuerError(message)
+
+
+def _build_response(message, status, headers=None):
+        if headers is None:
+            headers = {}
+
+        response = HttpResponse(message, status=status)
+        for header, value in headers.items():
+            response[header] = value
+
+        return response

--- a/atlassian_jwt_auth/contrib/flask_app/decorators.py
+++ b/atlassian_jwt_auth/contrib/flask_app/decorators.py
@@ -43,4 +43,4 @@ def _get_verifier():
 
 
 def _build_response(message, status, headers=None):
-        return Response(message, status=status, headers=headers)
+    return Response(message, status=status, headers=headers)

--- a/atlassian_jwt_auth/contrib/server/helpers.py
+++ b/atlassian_jwt_auth/contrib/server/helpers.py
@@ -25,7 +25,7 @@ def _requires_asap(verifier, auth, parse_jwt_func, build_response_func,
     message, exception = None, None
     if not auth or len(auth) != 2 or auth[0].lower() != b'bearer':
         return build_response_func('Unauthorized', status=401, headers={
-                              'WWW-Authenticate': 'Bearer'})
+            'WWW-Authenticate': 'Bearer'})
     try:
         asap_claims = parse_jwt_func(verifier, auth[1])
         if verify_issuers_func is not None:

--- a/atlassian_jwt_auth/contrib/tests/django/test_django.py
+++ b/atlassian_jwt_auth/contrib/tests/django/test_django.py
@@ -128,13 +128,24 @@ class TestAsapMiddleware(DjangoAsapMixin, RS256KeyTestMixin, SimpleTestCase):
                             retriever_key='unexpected/key01')
 
     def test_request_non_decorated_issuer_is_rejected(self):
-        self.check_response('restricted', 'Forbidden', 403)
+        self.check_response('restricted_issuer', 'Forbidden', 403)
 
     def test_request_decorated_issuer_is_allowed(self):
-        self.check_response('restricted', 'three',
+        self.check_response('restricted_issuer', 'three',
                             issuer='whitelist',
                             key_id='whitelist/key01',
                             retriever_key='whitelist/key01')
+
+    # TODO: modify JWTAuthSigner to allow non-issuer subjects and update the
+    # decorated subject test cases
+    def test_request_non_decorated_subject_is_rejected(self):
+        self.check_response('restricted_subject', 'Forbidden', 403,
+                            issuer='whitelist',
+                            key_id='whitelist/key01',
+                            retriever_key='whitelist/key01')
+
+    def test_request_decorated_subject_is_allowed(self):
+        self.check_response('restricted_subject', 'four')
 
     def test_request_using_settings_only_is_allowed(self):
         self.check_response('unneeded', 'two')

--- a/atlassian_jwt_auth/contrib/tests/django/test_django.py
+++ b/atlassian_jwt_auth/contrib/tests/django/test_django.py
@@ -2,7 +2,7 @@ import os
 
 import django
 from django.test.testcases import SimpleTestCase
-from django.test.utils import override_settings
+from django.test.utils import override_settings, modify_settings
 try:
     from django.urls import reverse
 except ImportError:
@@ -17,6 +17,124 @@ from atlassian_jwt_auth.tests.utils import RS256KeyTestMixin
 def create_token(issuer, audience, key_id, private_key):
     signer = create_signer(issuer, key_id, private_key)
     return signer.generate_jwt(audience)
+
+
+@modify_settings(MIDDLEWARE={
+    'prepend': 'atlassian_jwt_auth.contrib.django.middleware.ASAPMiddleware',
+})
+class TestAsapMiddleware(RS256KeyTestMixin, SimpleTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        os.environ.setdefault(
+            'DJANGO_SETTINGS_MODULE',
+            'atlassian_jwt_auth.contrib.tests.django.settings')
+
+        django.setup()
+        super(TestAsapMiddleware, cls).setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        super(TestAsapMiddleware, cls).tearDownClass()
+        del os.environ['DJANGO_SETTINGS_MODULE']
+
+    def setUp(self):
+        super(TestAsapMiddleware, self).setUp()
+        self._private_key_pem = self.get_new_private_key_in_pem_format()
+        self._public_key_pem = utils.get_public_key_pem_for_private_key_pem(
+            self._private_key_pem
+        )
+
+        self.retriever = get_static_retriever_class({
+            'client-app/key01': self._public_key_pem
+        })
+
+        self.test_settings = {
+            'ASAP_KEY_RETRIEVER_CLASS': self.retriever
+        }
+
+    def check_response(self,
+                       view_name,
+                       response_content='',
+                       status_code=200,
+                       issuer='client-app',
+                       audience='server-app',
+                       key_id='client-app/key01',
+                       private_key=None,
+                       token=None,
+                       authorization=None,
+                       retriever_key=None):
+        if authorization is None:
+            if token is None:
+                if private_key is None:
+                    private_key = self._private_key_pem
+                token = create_token(issuer=issuer, audience=audience,
+                                     key_id=key_id, private_key=private_key)
+            authorization = b'Bearer ' + token
+
+        test_settings = self.test_settings.copy()
+        if retriever_key is not None:
+            retriever = get_static_retriever_class({
+                retriever_key: self._public_key_pem
+            })
+            test_settings['ASAP_KEY_RETRIEVER_CLASS'] = retriever
+
+        with override_settings(**test_settings):
+            response = self.client.get(reverse(view_name),
+                                       HTTP_AUTHORIZATION=authorization)
+
+        self.assertContains(response, response_content,
+                            status_code=status_code)
+
+    def test_request_with_valid_token_is_allowed(self):
+        self.check_response('needed', 'one', 200)
+
+    def test_request_with_string_headers_is_allowed(self):
+        token = create_token(
+            issuer='client-app', audience='server-app',
+            key_id='client-app/key01', private_key=self._private_key_pem
+        )
+        str_auth = 'Bearer ' + token.decode(encoding='iso-8859-1')
+        self.check_response('needed', 'one', 200, authorization=str_auth)
+
+    def test_request_with_invalid_audience_is_rejected(self):
+        self.check_response('needed', 'Unauthorized', 401,
+                            audience='invalid')
+
+    def test_request_with_invalid_token_is_rejected(self):
+        self.check_response('needed', 'Unauthorized', 401,
+                            authorization='Bearer invalid')
+
+    def test_request_without_token_is_rejected(self):
+        with override_settings(**self.test_settings):
+            response = self.client.get(reverse('needed'))
+
+        self.assertContains(response, 'Unauthorized',
+                            status_code=401)
+
+    def test_request_with_invalid_issuer_is_rejected(self):
+        self.check_response('needed', 'Forbidden', 403,
+                            issuer='something-invalid',
+                            key_id='something-invalid/key01',
+                            retriever_key='something-invalid/key01')
+
+    def test_request_non_whitelisted_decorated_issuer_is_rejected(self):
+        self.check_response('needed', 'Forbidden', 403,
+                            issuer='unexpected',
+                            key_id='unexpected/key01',
+                            retriever_key='unexpected/key01')
+
+    def test_request_non_decorated_issuer_is_rejected(self):
+        self.check_response('restricted', 'Forbidden', 403)
+
+    def test_request_decorated_issuer_is_allowed(self):
+        self.check_response('restricted', 'three',
+                            issuer='whitelist',
+                            key_id='whitelist/key01',
+                            retriever_key='whitelist/key01')
+
+    def test_request_using_settings_only_is_allowed(self):
+        self.check_response('unneeded', 'two')
 
 
 class TestAsapDecorator(RS256KeyTestMixin, SimpleTestCase):

--- a/atlassian_jwt_auth/contrib/tests/django/urls.py
+++ b/atlassian_jwt_auth/contrib/tests/django/urls.py
@@ -11,5 +11,8 @@ urlpatterns = [
 
     url(r'^asap/needed$', views.needed_view, name='needed'),
     url(r'^asap/unneeded$', views.unneeded_view, name='unneeded'),
-    url(r'^asap/restricted$', views.restricted_view, name='restricted'),
+    url(r'^asap/restricted_issuer$', views.restricted_issuer_view,
+        name='restricted_issuer'),
+    url(r'^asap/restricted_subject$', views.restricted_subject_view,
+        name='restricted_subject'),
 ]

--- a/atlassian_jwt_auth/contrib/tests/django/urls.py
+++ b/atlassian_jwt_auth/contrib/tests/django/urls.py
@@ -7,5 +7,9 @@ urlpatterns = [
     url(r'^asap/expected$', views.expected_view, name='expected'),
     url(r'^asap/unexpected$', views.unexpected_view, name='unexpected'),
     url(r'^asap/decorated$', views.decorated_view, name='decorated'),
-    url(r'^asap/settings$', views.settings_view, name='settings')
+    url(r'^asap/settings$', views.settings_view, name='settings'),
+
+    url(r'^asap/needed$', views.needed_view, name='needed'),
+    url(r'^asap/unneeded$', views.unneeded_view, name='unneeded'),
+    url(r'^asap/restricted$', views.restricted_view, name='restricted'),
 ]

--- a/atlassian_jwt_auth/contrib/tests/django/views.py
+++ b/atlassian_jwt_auth/contrib/tests/django/views.py
@@ -35,5 +35,10 @@ def unneeded_view(request):
 
 
 @validate_asap(issuers=['whitelist'])
-def restricted_view(request):
+def restricted_issuer_view(request):
     return HttpResponse('three')
+
+
+@validate_asap(subjects=['client-app'])
+def restricted_subject_view(request):
+    return HttpResponse('four')

--- a/atlassian_jwt_auth/contrib/tests/django/views.py
+++ b/atlassian_jwt_auth/contrib/tests/django/views.py
@@ -1,6 +1,7 @@
 from django.http import HttpResponse
 
-from atlassian_jwt_auth.contrib.django.decorators import requires_asap
+from atlassian_jwt_auth.contrib.django.decorators import (requires_asap,
+                                                          validate_asap)
 
 
 @requires_asap(issuers=['client-app'])
@@ -21,3 +22,18 @@ def decorated_view(request):
 @requires_asap()
 def settings_view(request):
     return HttpResponse('Any settings issuer is allowed.')
+
+
+@validate_asap()
+def needed_view(request):
+    return HttpResponse('one')
+
+
+@validate_asap(required=False)
+def unneeded_view(request):
+    return HttpResponse('two')
+
+
+@validate_asap(issuers=['whitelist'])
+def restricted_view(request):
+    return HttpResponse('three')

--- a/atlassian_jwt_auth/exceptions.py
+++ b/atlassian_jwt_auth/exceptions.py
@@ -6,6 +6,7 @@ class _WrappedException(object):
     they're mutually incompatible. This is a simple, portable approach that
     should be sufficient for most use cases.
     """
+
     def __init__(self, *args, **kwargs):
         if args:
             orig = args[0]
@@ -22,6 +23,7 @@ class _WithStatus(object):
     This should allow inspecting HTTP-related errors without having to know
     details about the HTTP client library.
     """
+
     def __init__(self, *args, **kwargs):
         status_code = kwargs.pop('status_code', None)
         super(_WithStatus, self).__init__(*args, **kwargs)


### PR DESCRIPTION
Django usually performs authentication in middleware, so that's where we should put ASAP-based authentication. But sometimes per-view authorization needs to occur, so we still need a view decorator to handle this.

`ASAPMiddleware` handles ASAP claim validation, including authentication and global authorization.

`validate_asap` handles per-view authorization, and can optionally reject unauthenticated requests for applications that do not want ASAP enabled globally.

This is also an opportunity to fix an issue with `ASAPForwardedMiddleware`, which will unintuitively run other middleware-based authentication before any ASAP authentication.