### PR TITLE
Sem-Ver: bugfix Use the raw string notation when specifying the key identifier regex

### DIFF
--- a/atlassian_jwt_auth/key.py
+++ b/atlassian_jwt_auth/key.py
@@ -38,7 +38,7 @@ class KeyIdentifier(object):
 
 def validate_key_identifier(identifier):
     """ returns a validated key identifier. """
-    regex = re.compile('^[\w.\-\+/]*$')
+    regex = re.compile(r'^[\w.\-\+/]*$')
     _error_msg = 'Invalid key identifier %s' % identifier
     if not identifier:
         raise KeyIdentifierException(_error_msg)


### PR DESCRIPTION

Signed-off-by: David Black <dblack@atlassian.com>