### PR TITLE
Sem-Ver: bugfix The HTTPSMultiRepositoryPublicKeyRetriever should try the next key repository upon encountering a server error (status code >= 500).

### DIFF
--- a/atlassian_jwt_auth/key.py
+++ b/atlassian_jwt_auth/key.py
@@ -136,7 +136,10 @@ class HTTPSMultiRepositoryPublicKeyRetriever(BasePublicKeyRetriever):
         for retriever in self._retrievers:
             try:
                 return retriever.retrieve(key_identifier, **requests_kwargs)
-            except RequestException as e:
+            except (RequestException, PublicKeyRetrieverException) as e:
+                if isinstance(e, PublicKeyRetrieverException):
+                    if e.status_code is None or e.status_code < 500:
+                        raise
                 logger = logging.getLogger(__name__)
                 logger.warn('Unable to retrieve public key from store',
                             extra={'underlying_error': str(e),

--- a/atlassian_jwt_auth/tests/test_public_key_provider.py
+++ b/atlassian_jwt_auth/tests/test_public_key_provider.py
@@ -125,6 +125,23 @@ class BaseHTTPSMultiRepositoryPublicKeyRetrieverTest(
             retriever.retrieve('example/eg'),
             self._public_key_pem)
 
+    @mock.patch.object(requests.Session, 'get')
+    def test_retrieve_with_500_error(self, mock_get_method):
+        """ tests that the retrieve method works as expected
+            when the first key repository returns a server error response.
+        """
+        retriever = HTTPSMultiRepositoryPublicKeyRetriever(self.keystore_urls)
+        _setup_mock_response_for_retriever(
+            mock_get_method, self._public_key_pem)
+        valid_response = mock_get_method.return_value
+        del mock_get_method.return_value
+        server_exception = requests.exceptions.HTTPError(
+            response=mock.Mock(status_code=500))
+        mock_get_method.side_effect = [server_exception, valid_response]
+        self.assertEqual(
+            retriever.retrieve('example/eg'),
+            self._public_key_pem)
+
 
 def _setup_mock_response_for_retriever(
         mock_method, public_key_pem, headers=None):


### PR DESCRIPTION
Signed-off-by: David Black <dblack@atlassian.com>