### PR TITLE
frameworks: Add support for ASAP_EXCLUDE_PATHS to exlcude paths from ASAP

### DIFF
--- a/atlassian_jwt_auth/frameworks/common/asap.py
+++ b/atlassian_jwt_auth/frameworks/common/asap.py
@@ -14,6 +14,13 @@ def _process_asap_token(request, backend, settings):
     if token is None and not settings.ASAP_REQUIRED and (
             settings.ASAP_REQUIRED is not None):
         return
+
+    if request and settings.ASAP_EXCLUDE_PATHS:
+        path = request.environ.get('PATH_INFO')
+        excluded_paths = settings.ASAP_EXCLUDE_PATHS
+        if any([excluded.match(path) for excluded in excluded_paths]):
+            return
+
     try:
         if token is None:
             raise NoTokenProvidedError

--- a/atlassian_jwt_auth/frameworks/common/backend.py
+++ b/atlassian_jwt_auth/frameworks/common/backend.py
@@ -1,4 +1,5 @@
 from abc import ABCMeta, abstractmethod, abstractproperty
+import re
 
 from atlassian_jwt_auth import HTTPSPublicKeyRetriever, JWTAuthVerifier
 
@@ -38,7 +39,10 @@ class Backend():
         'ASAP_VALID_ISSUERS': None,
 
         # Enforce that the ASAP subject must match the issuer
-        'ASAP_SUBJECT_SHOULD_MATCH_ISSUER': None
+        'ASAP_SUBJECT_SHOULD_MATCH_ISSUER': None,
+
+        # Exclude the follow paths from ASAP authentications
+        'ASAP_EXCLUDE_PATHS': []
     }
 
     @abstractmethod
@@ -102,5 +106,11 @@ class Backend():
         valid_issuers = settings.get('ASAP_VALID_ISSUERS')
         if valid_issuers:
             settings['ASAP_VALID_ISSUERS'] = set(valid_issuers)
+
+        exclude_paths = settings.get('ASAP_EXCLUDE_PATHS')
+        if exclude_paths:
+            settings['ASAP_EXCLUDE_PATHS'] = [
+                re.compile(regex) for regex in exclude_paths
+            ]
 
         return SettingsDict(settings)

--- a/atlassian_jwt_auth/frameworks/django/tests/settings.py
+++ b/atlassian_jwt_auth/frameworks/django/tests/settings.py
@@ -111,3 +111,4 @@ STATIC_URL = '/static/'
 ASAP_VALID_AUDIENCE = 'server-app'
 ASAP_VALID_ISSUERS = ('client-app', 'whitelist')
 ASAP_PUBLICKEY_REPOSITORY = None
+ASAP_EXCLUDE_PATHS = ['/excluded']

--- a/atlassian_jwt_auth/frameworks/django/tests/test_django.py
+++ b/atlassian_jwt_auth/frameworks/django/tests/test_django.py
@@ -290,7 +290,7 @@ class TestAsapDecorator(DjangoAsapMixin, RS256KeyTestMixin, SimpleTestCase):
                 self.test_settings, ASAP_SUBJECT_SHOULD_MATCH_ISSUER=False)):
             message = 'Issuer does not match the subject'
             with self.assertRaisesRegexp(ValueError, message):
-                response = self.client.get(
+                self.client.get(
                     reverse('subject_does_need_to_match_issuer'),
                     HTTP_AUTHORIZATION=b'Bearer ' + token)
 

--- a/atlassian_jwt_auth/frameworks/django/tests/test_django.py
+++ b/atlassian_jwt_auth/frameworks/django/tests/test_django.py
@@ -47,7 +47,8 @@ class DjangoAsapMixin(object):
         })
 
         self.test_settings = {
-            'ASAP_KEY_RETRIEVER_CLASS': self.retriever
+            'ASAP_KEY_RETRIEVER_CLASS': self.retriever,
+            'ASAP_EXCLUDE_PATHS': ['/excluded']
         }
 
 
@@ -152,6 +153,10 @@ class TestAsapMiddleware(DjangoAsapMixin, RS256KeyTestMixin, SimpleTestCase):
     def test_request_subject_does_not_need_to_match_issuer_from_settings(self):
         self.test_settings['ASAP_SUBJECT_SHOULD_MATCH_ISSUER'] = False
         self.check_response('needed', 'one', 200, subject='different_than_is')
+
+    def test_request_with_excluded_path(self):
+        response = self.client.get('/excluded')
+        assert response.status_code == 200
 
 
 class TestAsapDecorator(DjangoAsapMixin, RS256KeyTestMixin, SimpleTestCase):

--- a/atlassian_jwt_auth/frameworks/django/tests/urls.py
+++ b/atlassian_jwt_auth/frameworks/django/tests/urls.py
@@ -26,4 +26,6 @@ urlpatterns = [
         name='restricted_issuer'),
     url(r'^asap/restricted_subject$', views.restricted_subject_view,
         name='restricted_subject'),
+
+    url(r'^excluded', views.excluded, name='excluded'),
 ]

--- a/atlassian_jwt_auth/frameworks/django/tests/views.py
+++ b/atlassian_jwt_auth/frameworks/django/tests/views.py
@@ -58,3 +58,7 @@ def restricted_issuer_view(request):
 @validate_asap(subjects=['client-app'])
 def restricted_subject_view(request):
     return HttpResponse('four')
+
+
+def excluded(request):
+    return HttpResponse('OK')


### PR DESCRIPTION
While integrating with one of our services, I realized that I didn't provide any mechanism in the middleware to allow an application author to exclude paths from the middleware.

This change adds a new `ASAP_EXCLUDE_PATHS` setting that allows an author to specify a list of regular expressions (as strings) that will be used to determine if a path should be excluded or not.