### PR TITLE
HTTP Caching: Share cache across key retriever instances

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,3 +11,4 @@ Mark Adams <madams@atlassian.com>
 Oleksandr Fedorov <a.g.fedorof@gmail.com>
 Sviatoslav Sydorenko <wk.cvs.github@sydorenko.org.ua>
 Waldemar Hummer <hummer@infosys.tuwien.ac.at>
+Erik van Zijst <erik.van.zijst@gmail.com>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,10 @@
 CHANGES
 =======
 
+4.1.3
+
+* Changed HTTP caching session to be shared among HTTPSPublicKeyRetriever instances
+
 4.1.2
 -----
 

--- a/atlassian_jwt_auth/contrib/aiohttp/key.py
+++ b/atlassian_jwt_auth/contrib/aiohttp/key.py
@@ -12,20 +12,21 @@ from atlassian_jwt_auth.key import (
 class HTTPSPublicKeyRetriever(_HTTPSPublicKeyRetriever):
     """A class for retrieving JWT public keys with aiohttp"""
 
+    _aiosession = None
+
     def __init__(self, base_url, *, loop=None):
         if loop is None:
             loop = asyncio.get_event_loop()
         self.loop = loop
         super().__init__(base_url)
-
-    def _get_session(self):
-        return aiohttp.ClientSession(loop=self.loop)
+        if self._aiosession is None:
+            self._aiosession = aiohttp.ClientSession(loop=self.loop)
 
     async def _retrieve(self, url, requests_kwargs):
         try:
-            resp = await self._session.get(url, headers={'accept':
-                                                         PEM_FILE_TYPE},
-                                           **requests_kwargs)
+            resp = await self._aiosession.get(url, headers={'accept':
+                                                            PEM_FILE_TYPE},
+                                              **requests_kwargs)
             resp.raise_for_status()
             self._check_content_type(url, resp.headers['content-type'])
             return await resp.text()

--- a/atlassian_jwt_auth/contrib/tests/aiohttp/test_public_key_provider.py
+++ b/atlassian_jwt_auth/contrib/tests/aiohttp/test_public_key_provider.py
@@ -8,12 +8,15 @@ from atlassian_jwt_auth.tests import utils
 
 
 class DummyHTTPSPublicKeyRetriever(HTTPSPublicKeyRetriever):
+    def __init__(self, base_url, *, loop=None):
+        super().__init__(base_url, loop=loop)
+        self._aiosession = self._get_session()
 
     def set_headers(self, headers):
-        self._session.get.return_value.headers.update(headers)
+        self._aiosession.get.return_value.headers.update(headers)
 
     def set_text(self, text):
-        self._session.get.return_value.text.return_value = text
+        self._aiosession.get.return_value.text.return_value = text
 
     def _get_session(self):
         session = Mock(spec=aiohttp.ClientSession)

--- a/atlassian_jwt_auth/key.py
+++ b/atlassian_jwt_auth/key.py
@@ -72,6 +72,9 @@ class HTTPSPublicKeyRetriever(BasePublicKeyRetriever):
     """ This class retrieves public key from a https location based upon the
          given key id.
     """
+    # Use a static requests session, reused/shared by all instances of
+    # HTTPSPublicKeyRetriever:
+    _session = None
 
     def __init__(self, base_url):
         if base_url is None or not base_url.startswith('https://'):
@@ -80,12 +83,12 @@ class HTTPSPublicKeyRetriever(BasePublicKeyRetriever):
         if not base_url.endswith('/'):
             base_url += '/'
         self.base_url = base_url
-        self._session = self._get_session()
-
-    def _get_session(self):
-        session = requests.Session()
-        session.mount('https://', cachecontrol.CacheControlAdapter())
-        return session
+        if HTTPSPublicKeyRetriever._session is None:
+            HTTPSPublicKeyRetriever._session = requests.Session()
+            HTTPSPublicKeyRetriever._session.mount(
+                'http://', cachecontrol.CacheControlAdapter())
+            HTTPSPublicKeyRetriever._session.mount(
+                'https://', cachecontrol.CacheControlAdapter())
 
     def retrieve(self, key_identifier, **requests_kwargs):
         """ returns the public key for given key_identifier. """

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,3 +2,4 @@ nose
 mock
 flask<1.1.0
 Django==1.11
+atlassian-httptest==0.8


### PR DESCRIPTION
This change makes it so that when instantiating the HTTPSPublicKeyRetriever class
multiple times, they all share the same requests session with cache.

Previously, each instance would create its own session with isolated cache. Since
the library by default always creates a new instance of the ASAP_KEY_RETRIEVER_CLASS
class (e.g. common.backend.Backend#get_verifier), cached responses were never reused.