### PR TITLE
Sem-Ver: api-break Re-use verifiers in the various middlewares and add an optional verifier argument to the _process_asap_token method.

### DIFF
--- a/atlassian_jwt_auth/frameworks/common/asap.py
+++ b/atlassian_jwt_auth/frameworks/common/asap.py
@@ -6,7 +6,7 @@ from atlassian_jwt_auth.exceptions import (
 )
 
 
-def _process_asap_token(request, backend, settings):
+def _process_asap_token(request, backend, settings, verifier=None):
     """ Verifies an ASAP token, validates the claims, and returns an error
     response"""
     token = backend.get_asap_token(request)
@@ -17,7 +17,8 @@ def _process_asap_token(request, backend, settings):
     try:
         if token is None:
             raise NoTokenProvidedError
-        verifier = backend.get_verifier(settings=settings)
+        if verifier is None:
+            verifier = backend.get_verifier(settings=settings)
         asap_claims = verifier.verify_jwt(
             token,
             settings.ASAP_VALID_AUDIENCE,

--- a/atlassian_jwt_auth/frameworks/django/middleware.py
+++ b/atlassian_jwt_auth/frameworks/django/middleware.py
@@ -6,9 +6,11 @@ def asap_middleware(get_response):
     """Middleware to enable ASAP for all requests"""
     backend = DjangoBackend()
     settings = backend.settings
+    _verifier = backend.get_verifier(settings=settings)
 
     def middleware(request):
-        error_response = _process_asap_token(request, backend, settings)
+        error_response = _process_asap_token(request, backend, settings,
+                                             verifier=_verifier)
         if error_response is not None:
             return error_response
 
@@ -24,10 +26,11 @@ class OldStyleASAPMiddleware(object):
     def __init__(self):
         self.backend = DjangoBackend()
         self.settings = self.backend.settings
+        self._verifier = backend.get_verifier(settings=self.settings)
 
     def process_request(self, request):
         error_response = _process_asap_token(
-            request, self.backend, self.settings
+            request, self.backend, self.settings, verifier=self._verifier
         )
         if error_response is not None:
             return error_response

--- a/atlassian_jwt_auth/frameworks/wsgi/middleware.py
+++ b/atlassian_jwt_auth/frameworks/wsgi/middleware.py
@@ -9,12 +9,13 @@ class ASAPMiddleware(object):
     def __init__(self, handler, settings):
         self._next = handler
         self._backend = WSGIBackend(settings)
+        self._verifier = self._backend.get_verifier()
 
     def __call__(self, environ, start_response):
         settings = self._backend.settings
         request = Request(environ, start_response)
         error_response = _process_asap_token(
-            request, self._backend, settings
+            request, self._backend, settings, verifier=self._verifier
         )
         if error_response is not None:
             return error_response


### PR DESCRIPTION


Signed-off-by: David Black <dblack@atlassian.com>