### PR TITLE
Sem-Ver: bugfix upgrade cryptography from using a version >= 2.5.0 < 2.6.0 to use a version >= 2.7.0 and < 2.8.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cryptography>=2.5.0,<2.6.0
+cryptography>=2.7.0,<2.8.0
 PyJWT>=1.5.2,<2.0.0
 requests>=2.8.1,<3.0.0
 CacheControl==0.12.5


### PR DESCRIPTION

Signed-off-by: David Black <dblack@atlassian.com>