### PR TITLE
Sem-Ver: feature Allow SettingsDict instances to be hashed.

### DIFF
--- a/atlassian_jwt_auth/frameworks/common/tests/test_utils.py
+++ b/atlassian_jwt_auth/frameworks/common/tests/test_utils.py
@@ -1,0 +1,20 @@
+import unittest
+
+from atlassian_jwt_auth.frameworks.common import utils
+
+
+class SettingsDictTest(unittest.TestCase):
+    """ Tests for the SettingsDict class. """
+
+    def test_hash(self):
+        """ Test that SettingsDict instances can be hashed. """
+        dictionary_one = {'a': 'b', '3': set([1]), 'f': None}
+        dictionary_two = {'a': 'b', '3': set([1]), 'f': None}
+        dictionary_three = {'a': 'b', '3': set([1]), 'diff': '333'}
+        settings_one = utils.SettingsDict(dictionary_one)
+        settings_two = utils.SettingsDict(dictionary_two)
+        settings_three = utils.SettingsDict(dictionary_three)
+        self.assertEqual(settings_one, settings_two)
+        self.assertEqual(hash(settings_one), hash(settings_two))
+        self.assertNotEqual(settings_one, settings_three)
+        self.assertNotEqual(hash(settings_one), hash(settings_three))

--- a/atlassian_jwt_auth/frameworks/common/utils.py
+++ b/atlassian_jwt_auth/frameworks/common/utils.py
@@ -7,3 +7,17 @@ class SettingsDict(dict):
 
     def __setitem__(self, key, value):
         raise AttributeError('SettingsDict properties are immutable')
+
+    def _hash_key(self):
+        keys_and_values = []
+        for key, value in self.items():
+            if isinstance(value, set):
+                value = frozenset(value)
+            keys_and_values.append("%s %s" % (key, hash(value)))
+        return frozenset(keys_and_values)
+
+    def __hash__(self):
+        return hash(self._hash_key())
+
+    def __eq__(self, other):
+        return hash(self) == hash(other)


### PR DESCRIPTION
Signed-off-by: David Black <dblack@atlassian.com>