### PR TITLE
Sem-Ver: bugfix For python 2.7 and 3.5 testing we need to pin itsdangerous to a version < 2.0.0.

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,7 @@
 nose
 mock
 Jinja2<3.0.0
+itsdangerous>=0.24,<2.0.0
 MarkupSafe<2.0.0
 flask<1.1.0
 Django>=1.11,<2.0.0


### PR DESCRIPTION


Signed-off-by: David Black <dblack@atlassian.com>