### PR TITLE
Sem-Ver: bugfix upgrade cryptography from using a version >= 3.1.0 < 3.2.0 to use a version >= 3.2.1 and < 3.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cryptography>=3.1.0,<3.2.0
+cryptography>=3.2.1,<3.3.0
 PyJWT>=1.5.2,<2.0.0
 requests>=2.8.1,<3.0.0
 CacheControl==0.12.6


### PR DESCRIPTION

Signed-off-by: David Black <dblack@atlassian.com>