### PR TITLE
Sem-Ver: api-break Drop support for python 3.5 as part of upgrading ccyptography from using a version >= 3.2.1 < 3.3.0 to use a version >= 3.3.1 and < 3.4.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: python
 python:
-  - "3.5"
   - "3.6"
   - "3.7"
   - "3.8"

--- a/README.rst
+++ b/README.rst
@@ -128,7 +128,7 @@ To verify a JWT
     verifier = atlassian_jwt_auth.JWTAuthVerifier(public_key_retriever)
     verified_claims = verifier.verify_jwt(a_jwt, 'audience')
 
-For Python versions starting from ``Python 3.5`` ``atlassian_jwt_auth.contrib.aiohttp``
+For Python versions starting from ``Python 3.5``, note this library no longer supports python 3.5, ``atlassian_jwt_auth.contrib.aiohttp``
 provides drop-in replacements for the components that
 perform HTTP requests, so that they use ``aiohttp`` instead of ``requests``:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cryptography>=3.2.1,<3.3.0
+cryptography>=3.3.1,<3.4.0
 PyJWT>=1.5.2,<2.0.0
 requests>=2.8.1,<3.0.0
 CacheControl==0.12.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,6 @@ classifier =
         Operating System :: OS Independent
         Programming Language :: Python
         Programming Language :: Python :: 3
-        Programming Language :: Python :: 3.5
         Programming Language :: Python :: 3.6
         Programming Language :: Python :: 3.7
         Programming Language :: Python :: 3.8


### PR DESCRIPTION


Signed-off-by: David Black <dblack@atlassian.com>