### PR TITLE
Sem-Ver: bugfix upgrade PyJWT from using a version >= 1.5.2 < 2.1.0 to use a version >= 1.5.2 and < 2.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cryptography>=3.3.1,<3.4.0
-PyJWT>=1.5.2,<2.1.0
+PyJWT>=1.5.2,<2.2.0
 requests>=2.8.1,<3.0.0
 CacheControl==0.12.6


### PR DESCRIPTION


Signed-off-by: David Black <dblack@atlassian.com>