### PR TITLE
* Sem-Ver: bugfix upgrade the version of Flask used for testing to be >= 2.0.3 and < 2.1.0.

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,8 +1,5 @@
 pytest<7.0.0
-Jinja2<3.0.0
-itsdangerous>=0.24,<2.0.0
-MarkupSafe<2.0.0
-flask<1.1.0
+flask>=2.0.3,<2.1.0
 Django>=2.2.8,<3.0.0
 atlassian-httptest==0.8
 aiohttp==3.7.4


### PR DESCRIPTION

Note: As part of this we no longer pin specific versions of Jinja2, itsdangerous or MarkupSafe.

Signed-off-by: David Black <dblack@atlassian.com>