### PR TITLE
Sem-Ver: bugfix Move away from using asynctest in python versions where unittest async utils are available (3.8 and above).

### DIFF
--- a/atlassian_jwt_auth/contrib/tests/aiohttp/test_public_key_provider.py
+++ b/atlassian_jwt_auth/contrib/tests/aiohttp/test_public_key_provider.py
@@ -2,8 +2,14 @@ import os
 from unittest import mock
 
 import aiohttp
-from asynctest import TestCase, Mock, CoroutineMock
 from multidict import CIMultiDict
+
+try:
+    from unittest import IsolatedAsyncioTestCase as TestCase
+    from unittest.mock import AsyncMock as CoroutineMock
+    from unittest.mock import Mock
+except ImportError:
+    from asynctest import CoroutineMock, TestCase, Mock
 
 from atlassian_jwt_auth.contrib.aiohttp import HTTPSPublicKeyRetriever
 from atlassian_jwt_auth.key import PEM_FILE_TYPE
@@ -28,6 +34,7 @@ class DummyHTTPSPublicKeyRetriever(HTTPSPublicKeyRetriever):
         resp = session.get.return_value
         resp.headers = CIMultiDict({"content-type": PEM_FILE_TYPE})
         resp.text = CoroutineMock(return_value='i-am-a-public-key')
+        resp.raise_for_status = Mock(name='raise_for_status')
         return session
 
 

--- a/atlassian_jwt_auth/contrib/tests/aiohttp/test_verifier.py
+++ b/atlassian_jwt_auth/contrib/tests/aiohttp/test_verifier.py
@@ -1,10 +1,14 @@
 import asyncio
 
-from asynctest import TestCase, CoroutineMock
+try:
+    from unittest import IsolatedAsyncioTestCase as TestCase
+    from unittest.mock import AsyncMock as CoroutineMock
+except ImportError:
+    from asynctest import TestCase, CoroutineMock
 
-from atlassian_jwt_auth.contrib.aiohttp import (
-    JWTAuthVerifier, HTTPSPublicKeyRetriever)
-from atlassian_jwt_auth.tests import utils, test_verifier
+from atlassian_jwt_auth.contrib.aiohttp import (HTTPSPublicKeyRetriever,
+                                                JWTAuthVerifier)
+from atlassian_jwt_auth.tests import test_verifier, utils
 
 
 class SyncJWTAuthVerifier(JWTAuthVerifier):


### PR DESCRIPTION

Signed-off-by: David Black <dblack@atlassian.com>